### PR TITLE
Feature/custom stacktrace

### DIFF
--- a/Example-Apps/Crash-Tester/AppDelegate+UI.m
+++ b/Example-Apps/Crash-Tester/AppDelegate+UI.m
@@ -489,13 +489,14 @@ MAKE_CATEGORIES_LOADABLE(AppDelegate_UI)
 - (NSArray*) crashCommands
 {
     NSMutableArray* commands = [NSMutableArray array];
+    __block AppDelegate* blockSelf = self;
     
     [commands addObject:
      [CommandEntry commandWithName:@"NSException"
                      accessoryType:UITableViewCellAccessoryNone
                              block:^(__unused UIViewController* controller)
       {
-          [self.crasher throwException];
+          [blockSelf.crasher throwException];
       }]];
     
     [commands addObject:
@@ -503,7 +504,7 @@ MAKE_CATEGORIES_LOADABLE(AppDelegate_UI)
                      accessoryType:UITableViewCellAccessoryNone
                              block:^(__unused UIViewController* controller)
       {
-          [self.crasher dereferenceBadPointer];
+          [blockSelf.crasher dereferenceBadPointer];
       }]];
     
     [commands addObject:
@@ -511,7 +512,7 @@ MAKE_CATEGORIES_LOADABLE(AppDelegate_UI)
                      accessoryType:UITableViewCellAccessoryNone
                              block:^(__unused UIViewController* controller)
       {
-          [self.crasher dereferenceNullPointer];
+          [blockSelf.crasher dereferenceNullPointer];
       }]];
     
     [commands addObject:
@@ -519,7 +520,7 @@ MAKE_CATEGORIES_LOADABLE(AppDelegate_UI)
                      accessoryType:UITableViewCellAccessoryNone
                              block:^(__unused UIViewController* controller)
       {
-          [self.crasher useCorruptObject];
+          [blockSelf.crasher useCorruptObject];
       }]];
     
     [commands addObject:
@@ -527,7 +528,7 @@ MAKE_CATEGORIES_LOADABLE(AppDelegate_UI)
                      accessoryType:UITableViewCellAccessoryNone
                              block:^(__unused UIViewController* controller)
       {
-          [self.crasher spinRunloop];
+          [blockSelf.crasher spinRunloop];
       }]];
     
     [commands addObject:
@@ -535,7 +536,7 @@ MAKE_CATEGORIES_LOADABLE(AppDelegate_UI)
                      accessoryType:UITableViewCellAccessoryNone
                              block:^(__unused UIViewController* controller)
       {
-          [self.crasher causeStackOverflow];
+          [blockSelf.crasher causeStackOverflow];
       }]];
     
     [commands addObject:
@@ -543,7 +544,7 @@ MAKE_CATEGORIES_LOADABLE(AppDelegate_UI)
                      accessoryType:UITableViewCellAccessoryNone
                              block:^(__unused UIViewController* controller)
       {
-          [self.crasher doAbort];
+          [blockSelf.crasher doAbort];
       }]];
     
     [commands addObject:
@@ -551,7 +552,7 @@ MAKE_CATEGORIES_LOADABLE(AppDelegate_UI)
                      accessoryType:UITableViewCellAccessoryNone
                              block:^(__unused UIViewController* controller)
       {
-          [self.crasher doDiv0];
+          [blockSelf.crasher doDiv0];
       }]];
     
     [commands addObject:
@@ -559,7 +560,7 @@ MAKE_CATEGORIES_LOADABLE(AppDelegate_UI)
                      accessoryType:UITableViewCellAccessoryNone
                              block:^(__unused UIViewController* controller)
       {
-          [self.crasher doIllegalInstruction];
+          [blockSelf.crasher doIllegalInstruction];
       }]];
 
     [commands addObject:
@@ -567,7 +568,7 @@ MAKE_CATEGORIES_LOADABLE(AppDelegate_UI)
                      accessoryType:UITableViewCellAccessoryNone
                              block:^(__unused UIViewController* controller)
       {
-          [self.crasher accessDeallocatedObject];
+          [blockSelf.crasher accessDeallocatedObject];
       }]];
 
     [commands addObject:
@@ -575,7 +576,7 @@ MAKE_CATEGORIES_LOADABLE(AppDelegate_UI)
                      accessoryType:UITableViewCellAccessoryNone
                              block:^(__unused UIViewController* controller)
       {
-          [self.crasher accessDeallocatedPtrProxy];
+          [blockSelf.crasher accessDeallocatedPtrProxy];
       }]];
 
     [commands addObject:
@@ -583,7 +584,7 @@ MAKE_CATEGORIES_LOADABLE(AppDelegate_UI)
                      accessoryType:UITableViewCellAccessoryNone
                              block:^(__unused UIViewController* controller)
       {
-          [self.crasher corruptMemory];
+          [blockSelf.crasher corruptMemory];
       }]];
 
     [commands addObject:
@@ -591,7 +592,7 @@ MAKE_CATEGORIES_LOADABLE(AppDelegate_UI)
                      accessoryType:UITableViewCellAccessoryNone
                              block:^(__unused UIViewController* controller)
       {
-          [self.crasher zombieNSException];
+          [blockSelf.crasher zombieNSException];
       }]];
 
     [commands addObject:
@@ -599,8 +600,8 @@ MAKE_CATEGORIES_LOADABLE(AppDelegate_UI)
                      accessoryType:UITableViewCellAccessoryNone
                              block:^(__unused UIViewController* controller)
       {
-          self.crashInHandler = YES;
-          [self.crasher dereferenceBadPointer];
+          blockSelf.crashInHandler = YES;
+          [blockSelf.crasher dereferenceBadPointer];
       }]];
 
     [commands addObject:
@@ -608,7 +609,7 @@ MAKE_CATEGORIES_LOADABLE(AppDelegate_UI)
                      accessoryType:UITableViewCellAccessoryNone
                              block:^(__unused UIViewController* controller)
       {
-          [self.crasher deadlock];
+          [blockSelf.crasher deadlock];
       }]];
 
     [commands addObject:
@@ -616,7 +617,7 @@ MAKE_CATEGORIES_LOADABLE(AppDelegate_UI)
                      accessoryType:UITableViewCellAccessoryNone
                              block:^(__unused UIViewController* controller)
       {
-          [self.crasher pthreadAPICrash];
+          [blockSelf.crasher pthreadAPICrash];
       }]];
 
     [commands addObject:
@@ -624,7 +625,7 @@ MAKE_CATEGORIES_LOADABLE(AppDelegate_UI)
                      accessoryType:UITableViewCellAccessoryNone
                              block:^(__unused UIViewController* controller)
       {
-          [self.crasher userDefinedCrash];
+          [blockSelf.crasher userDefinedCrash];
       }]];
 
 

--- a/Example-Apps/Crash-Tester/AppDelegate+UI.m
+++ b/Example-Apps/Crash-Tester/AppDelegate+UI.m
@@ -620,7 +620,7 @@ MAKE_CATEGORIES_LOADABLE(AppDelegate_UI)
       }]];
 
     [commands addObject:
-     [CommandEntry commandWithName:@"User Defined Crash"
+     [CommandEntry commandWithName:@"User Defined (soft) Crash"
                      accessoryType:UITableViewCellAccessoryNone
                              block:^(__unused UIViewController* controller)
       {

--- a/Example-Apps/Crash-Tester/AppDelegate+UI.m
+++ b/Example-Apps/Crash-Tester/AppDelegate+UI.m
@@ -610,7 +610,15 @@ MAKE_CATEGORIES_LOADABLE(AppDelegate_UI)
       {
           [self.crasher deadlock];
       }]];
-    
+
+    [commands addObject:
+     [CommandEntry commandWithName:@"Deadlock pthread"
+                     accessoryType:UITableViewCellAccessoryNone
+                             block:^(__unused UIViewController* controller)
+      {
+          [self.crasher pthreadAPICrash];
+      }]];
+
 
     return commands;
 }

--- a/Example-Apps/Crash-Tester/AppDelegate+UI.m
+++ b/Example-Apps/Crash-Tester/AppDelegate+UI.m
@@ -619,6 +619,14 @@ MAKE_CATEGORIES_LOADABLE(AppDelegate_UI)
           [self.crasher pthreadAPICrash];
       }]];
 
+    [commands addObject:
+     [CommandEntry commandWithName:@"User Defined Crash"
+                     accessoryType:UITableViewCellAccessoryNone
+                             block:^(__unused UIViewController* controller)
+      {
+          [self.crasher userDefinedCrash];
+      }]];
+
 
     return commands;
 }

--- a/Example-Apps/Crash-Tester/Crasher.h
+++ b/Example-Apps/Crash-Tester/Crasher.h
@@ -38,4 +38,6 @@
 
 - (void) pthreadAPICrash;
 
+- (void) userDefinedCrash;
+
 @end

--- a/Example-Apps/Crash-Tester/Crasher.h
+++ b/Example-Apps/Crash-Tester/Crasher.h
@@ -36,4 +36,6 @@
 
 - (void) deadlock;
 
+- (void) pthreadAPICrash;
+
 @end

--- a/Example-Apps/Crash-Tester/Crasher.m
+++ b/Example-Apps/Crash-Tester/Crasher.m
@@ -6,6 +6,7 @@
 
 #import "Crasher.h"
 #import "ARCSafe_MemMgmt.h"
+#import <KSCrash/KSCrash.h>
 #import <pthread.h>
 
 @interface MyClass: NSObject @end
@@ -208,6 +209,24 @@ int g_crasher_denominator = 0;
 {
     // http://landonf.bikemonkey.org/code/crashreporting
     pthread_getname_np(pthread_self(), (char*)0x1, 1);
+}
+
+- (void) userDefinedCrash
+{
+    NSString* name = @"Script Error";
+    NSString* reason = @"fragment is not defined";
+    NSString* lineOfCode = @"string.append(fragment)";
+    NSArray* stackTrace = [NSArray arrayWithObjects:
+                           @"Printer.script, line 174: in function assembleComponents",
+                           @"Printer.script, line 209: in function print",
+                           @"Main.script, line 10: in function initialize",
+                           nil];
+
+    [[KSCrash sharedInstance] reportUserException:name
+                                           reason:reason
+                                       lineOfCode:lineOfCode
+                                       stackTrace:stackTrace
+                                 terminateProgram:YES];
 }
 
 @end

--- a/Example-Apps/Crash-Tester/Crasher.m
+++ b/Example-Apps/Crash-Tester/Crasher.m
@@ -226,7 +226,7 @@ int g_crasher_denominator = 0;
                                            reason:reason
                                        lineOfCode:lineOfCode
                                        stackTrace:stackTrace
-                                 terminateProgram:YES];
+                                 terminateProgram:NO];
 }
 
 @end

--- a/Example-Apps/Crash-Tester/Crasher.m
+++ b/Example-Apps/Crash-Tester/Crasher.m
@@ -6,6 +6,7 @@
 
 #import "Crasher.h"
 #import "ARCSafe_MemMgmt.h"
+#import <pthread.h>
 
 @interface MyClass: NSObject @end
 @implementation MyClass @end
@@ -201,6 +202,12 @@ int g_crasher_denominator = 0;
                    {
                        [self.lock lock];
                    });
+}
+
+- (void) pthreadAPICrash
+{
+    // http://landonf.bikemonkey.org/code/crashreporting
+    pthread_getname_np(pthread_self(), (char*)0x1, 1);
 }
 
 @end

--- a/KSCrash/KSCrash.xcodeproj/project.pbxproj
+++ b/KSCrash/KSCrash.xcodeproj/project.pbxproj
@@ -374,6 +374,12 @@
 		CB7C754716CD5F5F00227870 /* KSCrashInstallation.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7C754216CD5F5F00227870 /* KSCrashInstallation.m */; };
 		CB7C754816CD5F5F00227870 /* KSCrashInstallation.m in Sources */ = {isa = PBXBuildFile; fileRef = CB7C754216CD5F5F00227870 /* KSCrashInstallation.m */; };
 		CBC74E9E169FD6FC001A688D /* GCDAProfiling.c in Sources */ = {isa = PBXBuildFile; fileRef = CBC74E9D169FD6FC001A688D /* GCDAProfiling.c */; };
+		CBCED885175E565B00BF56F0 /* KSCrashSentry_User.h in Headers */ = {isa = PBXBuildFile; fileRef = CBCED884175E565B00BF56F0 /* KSCrashSentry_User.h */; };
+		CBCED886175E565B00BF56F0 /* KSCrashSentry_User.h in Headers */ = {isa = PBXBuildFile; fileRef = CBCED884175E565B00BF56F0 /* KSCrashSentry_User.h */; };
+		CBCED887175E565B00BF56F0 /* KSCrashSentry_User.h in Headers */ = {isa = PBXBuildFile; fileRef = CBCED884175E565B00BF56F0 /* KSCrashSentry_User.h */; };
+		CBCED88D175E567F00BF56F0 /* KSCrashSentry_User.c in Sources */ = {isa = PBXBuildFile; fileRef = CBCED88C175E567F00BF56F0 /* KSCrashSentry_User.c */; };
+		CBCED88E175E567F00BF56F0 /* KSCrashSentry_User.c in Sources */ = {isa = PBXBuildFile; fileRef = CBCED88C175E567F00BF56F0 /* KSCrashSentry_User.c */; };
+		CBCED88F175E567F00BF56F0 /* KSCrashSentry_User.c in Sources */ = {isa = PBXBuildFile; fileRef = CBCED88C175E567F00BF56F0 /* KSCrashSentry_User.c */; };
 		CBD9A64416E3E875007142EE /* KSCrashInstallationEmail_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CBD9A64316E3E875007142EE /* KSCrashInstallationEmail_Tests.m */; };
 		CBD9A64716E3EC02007142EE /* KSCrashInstallationQuincyHockey_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CBD9A64616E3EC02007142EE /* KSCrashInstallationQuincyHockey_Tests.m */; };
 		CBD9A64A16E3F424007142EE /* KSCrashInstallationStandard_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CBD9A64916E3F424007142EE /* KSCrashInstallationStandard_Tests.m */; };
@@ -591,6 +597,8 @@
 		CB7C754116CD5F5E00227870 /* KSCrashInstallation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSCrashInstallation.h; sourceTree = "<group>"; };
 		CB7C754216CD5F5F00227870 /* KSCrashInstallation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSCrashInstallation.m; sourceTree = "<group>"; };
 		CBC74E9D169FD6FC001A688D /* GCDAProfiling.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = GCDAProfiling.c; path = XcodeCoverage/GCDAProfiling.c; sourceTree = SOURCE_ROOT; };
+		CBCED884175E565B00BF56F0 /* KSCrashSentry_User.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSCrashSentry_User.h; sourceTree = "<group>"; };
+		CBCED88C175E567F00BF56F0 /* KSCrashSentry_User.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = KSCrashSentry_User.c; sourceTree = "<group>"; };
 		CBD9A64316E3E875007142EE /* KSCrashInstallationEmail_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSCrashInstallationEmail_Tests.m; sourceTree = "<group>"; };
 		CBD9A64616E3EC02007142EE /* KSCrashInstallationQuincyHockey_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSCrashInstallationQuincyHockey_Tests.m; sourceTree = "<group>"; };
 		CBD9A64916E3F424007142EE /* KSCrashInstallationStandard_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSCrashInstallationStandard_Tests.m; sourceTree = "<group>"; };
@@ -867,6 +875,8 @@
 				39DA83A71618450A001E7F79 /* KSCrashSentry_Private.h */,
 				39DA83A81618450A001E7F79 /* KSCrashSentry_Signal.c */,
 				39DA83A91618450A001E7F79 /* KSCrashSentry_Signal.h */,
+				CBCED884175E565B00BF56F0 /* KSCrashSentry_User.h */,
+				CBCED88C175E567F00BF56F0 /* KSCrashSentry_User.c */,
 			);
 			name = Sentry;
 			sourceTree = "<group>";
@@ -1042,6 +1052,7 @@
 				CB1B378616D820AE00FFFCEA /* KSSingleton.h in Headers */,
 				CBF2D93A16DE86B00003AD7E /* KSCrashInstallationEmail.h in Headers */,
 				CBF2D94016DEDCC10003AD7E /* KSCrashInstallationStandard.h in Headers */,
+				CBCED885175E565B00BF56F0 /* KSCrashSentry_User.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1115,6 +1126,7 @@
 				CB1B378816D820AE00FFFCEA /* KSSingleton.h in Headers */,
 				CBF2D93B16DE86B00003AD7E /* KSCrashInstallationEmail.h in Headers */,
 				CBF2D94116DEDCC10003AD7E /* KSCrashInstallationStandard.h in Headers */,
+				CBCED887175E565B00BF56F0 /* KSCrashSentry_User.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1177,6 +1189,7 @@
 				CB7C754416CD5F5F00227870 /* KSCrashInstallation.h in Headers */,
 				CB1B377016D74F3C00FFFCEA /* KSCString.h in Headers */,
 				CB1B378716D820AE00FFFCEA /* KSSingleton.h in Headers */,
+				CBCED886175E565B00BF56F0 /* KSCrashSentry_User.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1432,6 +1445,7 @@
 				CBF2D94216DEDCC10003AD7E /* KSCrashInstallationStandard.m in Sources */,
 				2122BBD116F185120056D11C /* KSCrashReportSinkTakanashi.m in Sources */,
 				2193ACC616F19D690016EA5F /* KSCrashInstallationTakanashi.m in Sources */,
+				CBCED88D175E567F00BF56F0 /* KSCrashSentry_User.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1495,6 +1509,7 @@
 				CBF2D94316DEDCC10003AD7E /* KSCrashInstallationStandard.m in Sources */,
 				2122BBD216F185120056D11C /* KSCrashReportSinkTakanashi.m in Sources */,
 				2193ACC716F19D690016EA5F /* KSCrashInstallationTakanashi.m in Sources */,
+				CBCED88F175E567F00BF56F0 /* KSCrashSentry_User.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1588,6 +1603,7 @@
 				CB5A5B4716C718C500DC1D2D /* KSCrashCallCompletion.m in Sources */,
 				CB7C754716CD5F5F00227870 /* KSCrashInstallation.m in Sources */,
 				CB1B377316D74F3C00FFFCEA /* KSCString.m in Sources */,
+				CBCED88E175E567F00BF56F0 /* KSCrashSentry_User.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/KSCrash/KSCrash/KSBacktrace.c
+++ b/KSCrash/KSCrash/KSBacktrace.c
@@ -383,7 +383,11 @@ int ksbt_backtracePthread(const pthread_t thread,
                           uintptr_t* const backtraceBuffer,
                           const int maxEntries)
 {
-    const thread_t mach_thread = pthread_mach_thread_np(thread);
+    const thread_t mach_thread = ksmach_machThreadFromPThread(thread);
+    if(mach_thread == 0)
+    {
+        return 0;
+    }
     return ksbt_backtraceThread(mach_thread, backtraceBuffer, maxEntries);
 }
 

--- a/KSCrash/KSCrash/KSCrash.h
+++ b/KSCrash/KSCrash/KSCrash.h
@@ -164,4 +164,26 @@ typedef enum
  */
 - (void) deleteAllReports;
 
+/** Report a custom, user defined exception.
+ * This can be useful when dealing with scripting languages.
+ *
+ * If terminateProgram is true, all sentries will be uninstalled and the application will
+ * terminate with an abort().
+ *
+ * @param name The exception name (for namespacing exception types).
+ *
+ * @param reason A description of why the exception occurred.
+ *
+ * @param lineOfCode A copy of the offending line of code (NULL = ignore).
+ *
+ * @param stackTrace An array of strings representing the call stack leading to the exception.
+ *
+ * @param terminateProgram If true, do not return from this function call. Terminate the program instead.
+ */
+- (void) reportUserException:(NSString*) name
+                      reason:(NSString*) reason
+                  lineOfCode:(NSString*) lineOfCode
+                  stackTrace:(NSArray*) stackTrace
+            terminateProgram:(BOOL) terminateProgram;
+
 @end

--- a/KSCrash/KSCrash/KSCrash.h
+++ b/KSCrash/KSCrash/KSCrash.h
@@ -174,9 +174,9 @@ typedef enum
  *
  * @param reason A description of why the exception occurred.
  *
- * @param lineOfCode A copy of the offending line of code (NULL = ignore).
+ * @param lineOfCode A copy of the offending line of code (nil = ignore).
  *
- * @param stackTrace An array of strings representing the call stack leading to the exception.
+ * @param stackTrace An array of strings representing the call stack leading to the exception (nil = ignore).
  *
  * @param terminateProgram If true, do not return from this function call. Terminate the program instead.
  */

--- a/KSCrash/KSCrash/KSCrash.m
+++ b/KSCrash/KSCrash/KSCrash.m
@@ -308,6 +308,33 @@ failed:
     [self.crashReportStore deleteAllReports];
 }
 
+- (void) reportUserException:(NSString*) name
+                      reason:(NSString*) reason
+                  lineOfCode:(NSString*) lineOfCode
+                  stackTrace:(NSArray*) stackTrace
+            terminateProgram:(BOOL) terminateProgram
+{
+    const char* cName = [name cStringUsingEncoding:NSUTF8StringEncoding];
+    const char* cReason = [reason cStringUsingEncoding:NSUTF8StringEncoding];
+    const char* cLineOfCode = [lineOfCode cStringUsingEncoding:NSUTF8StringEncoding];
+    size_t cStackTraceCount = [stackTrace count];
+    const char** cStackTrace = malloc(sizeof(*cStackTrace) * cStackTraceCount);
+
+    for(size_t i = 0; i < cStackTraceCount; i++)
+    {
+        cStackTrace[i] = [[stackTrace objectAtIndex:i] cStringUsingEncoding:NSUTF8StringEncoding];
+    }
+
+    kscrash_reportUserException(cName,
+                                cReason,
+                                cLineOfCode,
+                                cStackTrace,
+                                cStackTraceCount,
+                                terminateProgram);
+
+    free((void*)cStackTrace);
+}
+
 
 // ============================================================================
 #pragma mark - Advanced API -

--- a/KSCrash/KSCrash/KSCrash.m
+++ b/KSCrash/KSCrash/KSCrash.m
@@ -74,6 +74,9 @@
 @property(nonatomic, readwrite, retain) NSString* logFilePath;
 @property(nonatomic, readwrite, retain) NSString* nextCrashID;
 @property(nonatomic, readwrite, retain) KSCrashReportStore* crashReportStore;
+@property(nonatomic, readonly, retain) NSString* crashReportPath;
+@property(nonatomic, readonly, retain) NSString* recrashReportPath;
+@property(nonatomic, readonly, retain) NSString* stateFilePath;
 
 @end
 
@@ -136,7 +139,7 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(KSCrash)
         {
             goto failed;
         }
-        
+
         self.nextCrashID = [self generateUUIDString];
         self.crashReportStore = [KSCrashReportStore storeWithPath:storePath];
         self.deleteBehaviorAfterSendAll = KSCDeleteAlways;
@@ -238,16 +241,27 @@ failed:
     }
 }
 
+- (NSString*) crashReportPath
+{
+    return [self.crashReportStore pathToCrashReportWithID:self.nextCrashID];
+}
+
+- (NSString*) recrashReportPath
+{
+    return [self.crashReportStore pathToRecrashReportWithID:self.nextCrashID];
+}
+
+- (NSString*) stateFilePath
+{
+    NSString* stateFilename = [NSString stringWithFormat:@"%@" kCrashStateFilenameSuffix, self.bundleName];
+    return [self.crashReportStore.path stringByAppendingPathComponent:stateFilename];
+}
+
 - (BOOL) install
 {
-    NSString* crashReportPath = [self.crashReportStore pathToCrashReportWithID:self.nextCrashID];
-    NSString* recrashReportPath = [self.crashReportStore pathToRecrashReportWithID:self.nextCrashID];
-    NSString* stateFilename = [NSString stringWithFormat:@"%@" kCrashStateFilenameSuffix, self.bundleName];
-    NSString* stateFilePath = [self.crashReportStore.path stringByAppendingPathComponent:stateFilename];
-
-    if(!kscrash_install([crashReportPath UTF8String],
-                        [recrashReportPath UTF8String],
-                        [stateFilePath UTF8String],
+    if(!kscrash_install([self.crashReportPath UTF8String],
+                        [self.recrashReportPath UTF8String],
+                        [self.stateFilePath UTF8String],
                         [self.nextCrashID UTF8String]))
     {
         return false;
@@ -332,9 +346,18 @@ failed:
                                 cStackTraceCount,
                                 terminateProgram);
 
+    // If kscrash_reportUserException() returns, we did not terminate.
+    // Set up IDs and paths for the next crash.
+
+    self.nextCrashID = [self generateUUIDString];
+
+    kscrash_reinstall([self.crashReportPath UTF8String],
+                      [self.recrashReportPath UTF8String],
+                      [self.stateFilePath UTF8String],
+                      [self.nextCrashID UTF8String]);
+
     free((void*)cStackTrace);
 }
-
 
 // ============================================================================
 #pragma mark - Advanced API -

--- a/KSCrash/KSCrash/KSCrashC.c
+++ b/KSCrash/KSCrash/KSCrashC.c
@@ -34,11 +34,13 @@
 #include "KSSystemInfoC.h"
 #include "KSZombie.h"
 #include "KSCrashSentry_Deadlock.h"
+#include "KSCrashSentry_User.h"
 
 //#define KSLogger_LocalLevel TRACE
 #include "KSLogger.h"
 
 #include <errno.h>
+#include <execinfo.h>
 #include <fcntl.h>
 #include <mach/mach_time.h>
 #include <stdlib.h>
@@ -134,12 +136,12 @@ bool kscrash_install(const char* const crashReportFilePath,
 
         ksmach_init();
 
-        if(ksmach_isBeingTraced())
+        /*if(ksmach_isBeingTraced())
         {
             KSLOGBASIC_WARN("KSCrash: App is running in a debugger."
                             " Crash sentries have been disabled for the sanity of all.");
         }
-        else if(kscrashsentry_installWithContext(&context->crash,
+        else */if(kscrashsentry_installWithContext(&context->crash,
                                                  KSCrashTypeAll) == 0)
         {
             KSLOG_ERROR("Failed to install any handlers");
@@ -242,4 +244,19 @@ void kscrash_setCrashNotifyCallback(const KSReportWriteCallback onCrashNotify)
 {
     KSLOG_TRACE("Set onCrashNotify to %p", onCrashNotify);
     crashContext()->config.onCrashNotify = onCrashNotify;
+}
+
+void kscrash_reportUserException(const char* name,
+                                 const char* reason,
+                                 const char* lineOfCode,
+                                 const char** stackTrace,
+                                 size_t stackTraceCount,
+                                 bool terminateProgram)
+{
+    kscrashsentry_reportUserException(name,
+                                      reason,
+                                      lineOfCode,
+                                      stackTrace,
+                                      stackTraceCount,
+                                      terminateProgram);
 }

--- a/KSCrash/KSCrash/KSCrashC.c
+++ b/KSCrash/KSCrash/KSCrashC.c
@@ -132,6 +132,8 @@ bool kscrash_install(const char* const crashReportFilePath,
         KSCrash_Context* context = crashContext();
         context->crash.onCrash = kscrash_i_onCrash;
 
+        ksmach_init();
+
         if(ksmach_isBeingTraced())
         {
             KSLOGBASIC_WARN("KSCrash: App is running in a debugger."

--- a/KSCrash/KSCrash/KSCrashC.h
+++ b/KSCrash/KSCrash/KSCrashC.h
@@ -165,7 +165,7 @@ void kscrash_setCrashNotifyCallback(const KSReportWriteCallback onCrashNotify);
  *
  * @param stackTrace An array of strings representing the call stack leading to the exception.
  *
- * @param stackTraceCount The length of the stack trace array.
+ * @param stackTraceCount The length of the stack trace array (0 = ignore).
  *
  * @param terminateProgram If true, do not return from this function call. Terminate the program instead.
  */

--- a/KSCrash/KSCrash/KSCrashC.h
+++ b/KSCrash/KSCrash/KSCrashC.h
@@ -137,6 +137,29 @@ void kscrash_setDoNotIntrospectClasses(const char** doNotIntrospectClasses, size
 void kscrash_setCrashNotifyCallback(const KSReportWriteCallback onCrashNotify);
 
 
+/** Report a custom, user defined exception.
+ * This can be useful when dealing with scripting languages.
+ *
+ * If terminateProgram is true, all sentries will be uninstalled and the application will
+ * terminate with an abort().
+ *
+ * @param reason A description of why the exception occurred.
+ *
+ * @param lineOfCode A copy of the offending line of code (NULL = ignore).
+ *
+ * @param stackTrace An array of strings representing the call stack leading to the exception.
+ *
+ * @param stackTraceCount The length of the stack trace array.
+ *
+ * @param terminateProgram If true, do not return from this function call. Terminate the program instead.
+ */
+void kscrash_reportUserException(const char* name,
+                                 const char* reason,
+                                 const char* lineOfCode,
+                                 const char** stackTrace,
+                                 size_t stackTraceCount,
+                                 bool terminateProgram);
+
 #ifdef __cplusplus
 }
 #endif

--- a/KSCrash/KSCrash/KSCrashC.h
+++ b/KSCrash/KSCrash/KSCrashC.h
@@ -61,6 +61,23 @@ bool kscrash_install(const char* const crashReportFilePath,
                      const char* stateFilePath,
                      const char* crashID);
 
+/** Reinstall the crash reporter. Useful for resetting the crash reporter
+ * after a "soft" crash.
+ *
+ * @param crashReportFilePath The file to store the next crash report to.
+ *
+ * @param recrashReportFilePath If the system crashes during crash handling,
+ *                              store a second, minimal report here.
+ *
+ * @param stateFilePath File to store persistent state in.
+ *
+ * @param crashID The unique identifier to assign to the next crash report.
+ */
+void kscrash_reinstall(const char* const crashReportFilePath,
+                       const char* const recrashReportFilePath,
+                       const char* const stateFilePath,
+                       const char* const crashID);
+
 /** Set the user-supplied data in JSON format.
  *
  * @param userInfoJSON Pre-baked JSON containing user-supplied information.
@@ -135,7 +152,6 @@ void kscrash_setDoNotIntrospectClasses(const char** doNotIntrospectClasses, size
  * Default: NULL
  */
 void kscrash_setCrashNotifyCallback(const KSReportWriteCallback onCrashNotify);
-
 
 /** Report a custom, user defined exception.
  * This can be useful when dealing with scripting languages.

--- a/KSCrash/KSCrash/KSCrashReport.c
+++ b/KSCrash/KSCrash/KSCrashReport.c
@@ -1413,15 +1413,12 @@ void kscrw_i_writeThread(const KSCrashReportWriter* const writer,
                                    isCrashedThread);
         }
         writer->addIntegerElement(writer, KSCrashField_Index, index);
-        if(pthread_getname_np(pthread_from_mach_thread_np(thread),
-                              nameBuffer,
-                              sizeof(nameBuffer)) == 0 &&
-           nameBuffer[0] != 0)
+        if(ksmach_getThreadName(thread, nameBuffer, sizeof(nameBuffer)) && nameBuffer[0] != 0)
         {
             writer->addStringElement(writer, KSCrashField_Name, nameBuffer);
         }
 
-        if(ksmach_getThreadQueueName(thread, nameBuffer, sizeof(nameBuffer)))
+        if(ksmach_getThreadQueueName(thread, nameBuffer, sizeof(nameBuffer)) && nameBuffer[0] != 0)
         {
             writer->addStringElement(writer,
                                      KSCrashField_DispatchQueue,

--- a/KSCrash/KSCrash/KSCrashReport.c
+++ b/KSCrash/KSCrash/KSCrashReport.c
@@ -56,7 +56,7 @@
 // ============================================================================
 
 /** Version number written to the report. */
-#define kReportVersionMajor 2
+#define kReportVersionMajor 3
 #define kReportVersionMinor 0
 
 /** Maximum depth allowed for a backtrace. */
@@ -157,14 +157,7 @@ void kscrw_i_addStringElement(const KSCrashReportWriter* const writer,
                               const char* const key,
                               const char* const value)
 {
-    if(key == NULL)
-    {
-        ksjson_addNullElement(getJsonContext(writer), key);
-    }
-    else
-    {
-        ksjson_addStringElement(getJsonContext(writer), key, value, strlen(value));
-    }
+    ksjson_addStringElement(getJsonContext(writer), key, value, strlen(value));
 }
 
 void kscrw_i_addTextFileElement(const KSCrashReportWriter* const writer,
@@ -464,10 +457,10 @@ uintptr_t* kscrw_i_getBacktrace(const KSCrash_SentryContext* const crash,
 {
     if(thread == crash->offendingThread)
     {
-        if(crash->crashType == KSCrashTypeNSException)
+        if(crash->crashType & (KSCrashTypeNSException | KSCrashTypeUserReported))
         {
-            *backtraceLength = crash->NSException.stackTraceLength;
-            return crash->NSException.stackTrace;
+            *backtraceLength = crash->stackTraceLength;
+            return crash->stackTrace;
         }
     }
 
@@ -544,7 +537,7 @@ void kscrw_i_logCrashType(const KSCrash_SentryContext* const sentryContext)
         {
             KSLOGBASIC_INFO("App crashed due to NSException: %s: %s",
                             sentryContext->NSException.name,
-                            sentryContext->NSException.reason);
+                            sentryContext->crashReason);
             break;
         }
         case KSCrashTypeSignal:
@@ -560,6 +553,11 @@ void kscrw_i_logCrashType(const KSCrash_SentryContext* const sentryContext)
         case KSCrashTypeMainThreadDeadlock:
         {
             KSLOGBASIC_INFO("Main thread deadlocked");
+            break;
+        }
+        case KSCrashTypeUserReported:
+        {
+            KSLOG_INFO("App crashed due to user specified exception: %s", sentryContext->crashReason);
             break;
         }
     }
@@ -1657,8 +1655,8 @@ void kscrw_i_writeError(const KSCrashReportWriter* const writer,
     kern_return_t machSubCode = 0;
     int sigNum = 0;
     int sigCode = 0;
-    const char* NSExceptionName = "(null)";
-    const char* NSExceptionReason = "(null)";
+    const char* NSExceptionName = NULL;
+    const char* crashReason = NULL;
 
     // Gather common info.
     switch(crash->crashType)
@@ -1684,19 +1682,18 @@ void kscrw_i_writeError(const KSCrashReportWriter* const writer,
         case KSCrashTypeNSException:
             machExceptionType = EXC_CRASH;
             sigNum = SIGABRT;
-            if(crash->NSException.name != NULL)
-            {
-                NSExceptionName = crash->NSException.name;
-            }
-            if(crash->NSException.reason != NULL)
-            {
-                NSExceptionReason = crash->NSException.reason;
-            }
+            NSExceptionName = crash->NSException.name;
+            crashReason = crash->crashReason;
             break;
         case KSCrashTypeSignal:
             sigNum = crash->signal.signalInfo->si_signo;
             sigCode = crash->signal.signalInfo->si_code;
             machExceptionType = kssignal_machExceptionForSignal(sigNum);
+            break;
+        case KSCrashTypeUserReported:
+            machExceptionType = EXC_CRASH;
+            sigNum = SIGABRT;
+            crashReason = crash->crashReason;
             break;
     }
 
@@ -1739,6 +1736,10 @@ void kscrw_i_writeError(const KSCrashReportWriter* const writer,
         writer->endContainer(writer);
 
         writer->addUIntegerElement(writer, KSCrashField_Address, crash->faultAddress);
+        if(crashReason != NULL)
+        {
+            writer->addStringElement(writer, KSCrashField_Reason, crashReason);
+        }
 
         // Gather specific info.
         switch(crash->crashType)
@@ -1757,8 +1758,7 @@ void kscrw_i_writeError(const KSCrashReportWriter* const writer,
                 writer->beginObject(writer, KSCrashField_NSException);
                 {
                     writer->addStringElement(writer, KSCrashField_Name, NSExceptionName);
-                    writer->addStringElement(writer, KSCrashField_Reason, NSExceptionReason);
-                    kscrw_i_writeAddressReferencedByString(writer, KSCrashField_ReferencedObject, NSExceptionReason);
+                    kscrw_i_writeAddressReferencedByString(writer, KSCrashField_ReferencedObject, crashReason);
                 }
                 writer->endContainer(writer);
                 break;
@@ -1766,6 +1766,32 @@ void kscrw_i_writeError(const KSCrashReportWriter* const writer,
             case KSCrashTypeSignal:
                 writer->addStringElement(writer, KSCrashField_Type, KSCrashExcType_Signal);
                 break;
+
+            case KSCrashTypeUserReported:
+            {
+                writer->addStringElement(writer, KSCrashField_Type, KSCrashExcType_User);
+                writer->beginObject(writer, KSCrashField_UserReported);
+                {
+                    writer->addStringElement(writer, KSCrashField_Name, crash->userException.name);
+                    if(crash->userException.lineOfCode != NULL)
+                    {
+                        writer->addStringElement(writer, KSCrashField_LineOfCode, crash->userException.lineOfCode);
+                    }
+                    if(crash->userException.customStackTraceLength > 0)
+                    {
+                        writer->beginArray(writer, KSCrashField_Backtrace);
+                        {
+                            for(int i = 0; i < crash->userException.customStackTraceLength; i++)
+                            {
+                                writer->addStringElement(writer, NULL, crash->userException.customStackTrace[i]);
+                            }
+                        }
+                        writer->endContainer(writer);
+                    }
+                }
+                writer->endContainer(writer);
+                break;
+            }
         }
     }
     writer->endContainer(writer);
@@ -2041,13 +2067,6 @@ void kscrashreport_writeStandardReport(KSCrash_Context* const crashContext,
 
         kscrw_i_writeBinaryImages(writer, KSCrashField_BinaryImages);
 
-        writer->beginObject(writer, KSCrashField_Crash);
-        {
-            kscrw_i_writeAllThreads(writer, KSCrashField_Threads, &crashContext->crash, crashContext->config.introspectionRules.enabled);
-            kscrw_i_writeError(writer, KSCrashField_Error, &crashContext->crash);
-        }
-        writer->endContainer(writer);
-
         kscrw_i_writeProcessState(writer, KSCrashField_ProcessState);
 
         if(crashContext->config.systemInfoJSON != NULL)
@@ -2066,6 +2085,13 @@ void kscrashreport_writeStandardReport(KSCrash_Context* const crashContext,
         {
             kscrw_i_addJSONElement(writer, KSCrashField_User, crashContext->config.userInfoJSON);
         }
+
+        writer->beginObject(writer, KSCrashField_Crash);
+        {
+            kscrw_i_writeAllThreads(writer, KSCrashField_Threads, &crashContext->crash, crashContext->config.introspectionRules.enabled);
+            kscrw_i_writeError(writer, KSCrashField_Error, &crashContext->crash);
+        }
+        writer->endContainer(writer);
 
         if(crashContext->config.onCrashNotify != NULL)
         {

--- a/KSCrash/KSCrash/KSCrashReportFields.h
+++ b/KSCrash/KSCrash/KSCrashReportFields.h
@@ -51,6 +51,7 @@
 #define KSCrashExcType_Mach                "mach"
 #define KSCrashExcType_NSException         "nsexception"
 #define KSCrashExcType_Signal              "signal"
+#define KSCrashExcType_User                "user"
 
 
 #pragma mark - Common -
@@ -80,6 +81,7 @@
 #pragma mark - Backtrace -
 
 #define KSCrashField_InstructionAddr       "instruction_addr"
+#define KSCrashField_LineOfCode            "line_of_code"
 #define KSCrashField_ObjectAddr            "object_addr"
 #define KSCrashField_ObjectName            "object_name"
 #define KSCrashField_SymbolAddr            "symbol_addr"
@@ -130,9 +132,10 @@
 #define KSCrashField_ExceptionName         "exception_name"
 #define KSCrashField_Mach                  "mach"
 #define KSCrashField_NSException           "nsexception"
+#define KSCrashField_Reason                "reason"
 #define KSCrashField_Signal                "signal"
 #define KSCrashField_Subcode               "subcode"
-#define KSCrashField_Reason                "reason"
+#define KSCrashField_UserReported          "user_reported"
 
 
 #pragma mark - Process State -

--- a/KSCrash/KSCrash/KSCrashReportFilterAppleFmt.m
+++ b/KSCrash/KSCrash/KSCrashReportFilterAppleFmt.m
@@ -674,9 +674,11 @@ NSDictionary* g_registerOrders;
     {
         [str appendString:[self stringWithUncaughtExceptionName:[userException objectForKey:@KSCrashField_Name]
                                                          reason:[error objectForKey:@KSCrashField_Reason]]];
-        [str appendString:@"\n"];
-        [str appendString:[self userExceptionTrace:userException]];
-        [str appendString:@"\n"];
+        NSString* trace = [self userExceptionTrace:userException];
+        if(trace.length > 0)
+        {
+            [str appendFormat:@"\n%@\n", trace];
+        }
     }
 
     if([@KSCrashExcType_Deadlock isEqualToString:[error objectForKey:@KSCrashField_Type]])
@@ -697,7 +699,7 @@ NSDictionary* g_registerOrders;
 
 - (NSString*) userExceptionTrace:(NSDictionary*)userException
 {
-    NSMutableString* str = [NSMutableString stringWithString:@"Custom Backtrace:\n"];
+    NSMutableString* str = [NSMutableString string];
     NSString* line = [userException objectForKey:@KSCrashField_LineOfCode];
     if(line != nil)
     {
@@ -708,7 +710,12 @@ NSDictionary* g_registerOrders;
     {
         [str appendFormat:@"%@\n", entry];
     }
-    return str;
+
+    if(str.length > 0)
+    {
+        return [@"Custom Backtrace:\n" stringByAppendingString:str];
+    }
+    return @"";
 }
 
 - (NSString*) threadStringForThread:(NSDictionary*) thread

--- a/KSCrash/KSCrash/KSCrashSentry.c
+++ b/KSCrash/KSCrash/KSCrashSentry.c
@@ -94,12 +94,13 @@ static bool g_threads_are_running = true;
 // ============================================================================
 
 KSCrashType kscrashsentry_installWithContext(KSCrash_SentryContext* context,
-                                             KSCrashType crashTypes)
+                                             KSCrashType crashTypes,
+                                             void (*onCrash)(void))
 {
     KSLOG_DEBUG("Installing handlers with context %p, crash types 0x%x.", context, crashTypes);
     g_context = context;
-
-    context->handlingCrash = false;
+    kscrashsentry_clearContext(g_context);
+    g_context->onCrash = onCrash;
 
     KSCrashType installed = 0;
     for(size_t i = 0; i < g_sentriesCount; i++)
@@ -200,4 +201,17 @@ void kscrashsentry_resumeThreads(void)
         }
     }
     KSLOG_DEBUG("Resume complete.");
+}
+
+void kscrashsentry_clearContext(KSCrash_SentryContext* context)
+{
+    void (*onCrash)(void) = context->onCrash;
+    memset(context, 0, sizeof(*context));
+    context->onCrash = onCrash;
+}
+
+void kscrashsentry_beginHandlingCrash(KSCrash_SentryContext* context)
+{
+    kscrashsentry_clearContext(context);
+    context->handlingCrash = true;
 }

--- a/KSCrash/KSCrash/KSCrashSentry.c
+++ b/KSCrash/KSCrash/KSCrashSentry.c
@@ -32,6 +32,7 @@
 #include "KSCrashSentry_MachException.h"
 #include "KSCrashSentry_NSException.h"
 #include "KSCrashSentry_Signal.h"
+#include "KSCrashSentry_User.h"
 #include "KSMach.h"
 
 //#define KSLogger_LocalLevel TRACE
@@ -41,6 +42,43 @@
 // ============================================================================
 #pragma mark - Globals -
 // ============================================================================
+
+typedef struct
+{
+    KSCrashType crashType;
+    bool (*install)(KSCrash_SentryContext* context);
+    void (*uninstall)(void);
+} CrashSentry;
+
+static CrashSentry g_sentries[] =
+{
+    {
+        KSCrashTypeMachException,
+        kscrashsentry_installMachHandler,
+        kscrashsentry_uninstallMachHandler,
+    },
+    {
+        KSCrashTypeSignal,
+        kscrashsentry_installSignalHandler,
+        kscrashsentry_uninstallSignalHandler,
+    },
+    {
+        KSCrashTypeNSException,
+        kscrashsentry_installNSExceptionHandler,
+        kscrashsentry_uninstallNSExceptionHandler,
+    },
+    {
+        KSCrashTypeMainThreadDeadlock,
+        kscrashsentry_installDeadlockHandler,
+        kscrashsentry_uninstallDeadlockHandler,
+    },
+    {
+        KSCrashTypeUserReported,
+        kscrashsentry_installUserExceptionHandler,
+        kscrashsentry_uninstallUserExceptionHandler,
+    },
+};
+static size_t g_sentriesCount = sizeof(g_sentries) / sizeof(*g_sentries);
 
 /** Context to fill with crash information. */
 static KSCrash_SentryContext* g_context = NULL;
@@ -64,23 +102,18 @@ KSCrashType kscrashsentry_installWithContext(KSCrash_SentryContext* context,
     context->handlingCrash = false;
 
     KSCrashType installed = 0;
-    if((crashTypes & KSCrashTypeMainThreadDeadlock) && kscrashsentry_installDeadlockHandler(context))
+    for(size_t i = 0; i < g_sentriesCount; i++)
     {
-        installed |= KSCrashTypeMainThreadDeadlock;
+        CrashSentry* sentry = &g_sentries[i];
+        if(sentry->crashType & crashTypes)
+        {
+            if(sentry->install == NULL || sentry->install(context))
+            {
+                installed |= sentry->crashType;
+            }
+        }
     }
-    if((crashTypes & KSCrashTypeMachException) && kscrashsentry_installMachHandler(context))
-    {
-        installed |= KSCrashTypeMachException;
-    }
-    if((crashTypes & KSCrashTypeSignal) && kscrashsentry_installSignalHandler(context))
-    {
-        installed |= KSCrashTypeSignal;
-    }
-    if((crashTypes & KSCrashTypeNSException) && kscrashsentry_installNSExceptionHandler(context))
-    {
-        installed |= KSCrashTypeNSException;
-    }
-    
+
     KSLOG_DEBUG("Installation complete. Installed types 0x%x.", installed);
     return installed;
 }
@@ -88,21 +121,16 @@ KSCrashType kscrashsentry_installWithContext(KSCrash_SentryContext* context,
 void kscrashsentry_uninstall(KSCrashType crashTypes)
 {
     KSLOG_DEBUG("Uninstalling handlers with crash types 0x%x.", crashTypes);
-    if(crashTypes & KSCrashTypeMainThreadDeadlock)
+    for(size_t i = 0; i < g_sentriesCount; i++)
     {
-        kscrashsentry_uninstallDeadlockHandler();
-    }
-    if(crashTypes & KSCrashTypeMachException)
-    {
-        kscrashsentry_uninstallMachHandler();
-    }
-    if(crashTypes & KSCrashTypeSignal)
-    {
-        kscrashsentry_uninstallSignalHandler();
-    }
-    if(crashTypes & KSCrashTypeNSException)
-    {
-        kscrashsentry_uninstallNSExceptionHandler();
+        CrashSentry* sentry = &g_sentries[i];
+        if(sentry->crashType & crashTypes)
+        {
+            if(sentry->install != NULL)
+            {
+                sentry->uninstall();
+            }
+        }
     }
     KSLOG_DEBUG("Uninstall complete.");
 }

--- a/KSCrash/KSCrash/KSCrashSentry.h
+++ b/KSCrash/KSCrash/KSCrashSentry.h
@@ -166,10 +166,13 @@ typedef struct KSCrash_SentryContext
  *
  * @param crashTypes The crash types to install handlers for.
  *
+ * @param onCrash Function to call when a crash occurs.
+ *
  * @return which crash handlers were installed successfully.
  */
 KSCrashType kscrashsentry_installWithContext(KSCrash_SentryContext* context,
-                                             KSCrashType crashTypes);
+                                             KSCrashType crashTypes,
+                                             void (*onCrash)(void));
 
 /** Uninstall crash sentry.
  *

--- a/KSCrash/KSCrash/KSCrashSentry_Deadlock.h
+++ b/KSCrash/KSCrash/KSCrashSentry_Deadlock.h
@@ -43,7 +43,7 @@ extern "C" {
  *
  * @param context The crash context to fill out when a crash occurs.
  *
- * @param onCrash Called when a crash occurs.
+ * @return true if installation was succesful.
  */
 bool kscrashsentry_installDeadlockHandler(KSCrash_SentryContext* context);
 

--- a/KSCrash/KSCrash/KSCrashSentry_Deadlock.m
+++ b/KSCrash/KSCrash/KSCrashSentry_Deadlock.m
@@ -122,6 +122,9 @@ static NSTimeInterval g_watchdogInterval = 0;
 
 - (void) handleDeadlock
 {
+    kscrashsentry_beginHandlingCrash(g_context);
+
+    KSLOG_DEBUG("Filling out context.");
     g_context->crashType = KSCrashTypeMainThreadDeadlock;
     g_context->offendingThread = self.mainThread;
     g_context->registersAreValid = false;

--- a/KSCrash/KSCrash/KSCrashSentry_MachException.c
+++ b/KSCrash/KSCrash/KSCrashSentry_MachException.c
@@ -250,6 +250,9 @@ void* ksmachexc_i_handleExceptions(void* const userData)
                 exceptionMessage.code[0], exceptionMessage.code[1]);
     if(g_installed)
     {
+        bool wasHandlingCrash = g_context->handlingCrash;
+        kscrashsentry_beginHandlingCrash(g_context);
+
         KSLOG_DEBUG("Exception handler is installed. Continuing exception handling.");
 
         KSLOG_DEBUG("Suspending all threads");
@@ -272,7 +275,7 @@ void* ksmachexc_i_handleExceptions(void* const userData)
             ksmachexc_i_restoreExceptionPorts();
         }
 
-        if(g_context->handlingCrash)
+        if(wasHandlingCrash)
         {
             KSLOG_INFO("Detected crash in the crash reporter. Restoring original handlers.");
             // The crash reporter itself crashed. Make a note of this and
@@ -281,10 +284,7 @@ void* ksmachexc_i_handleExceptions(void* const userData)
             kscrashsentry_uninstall(KSCrashTypeAsyncSafe);
         }
 
-
         // Fill out crash information
-        g_context->handlingCrash = true;
-
         KSLOG_DEBUG("Fetching machine state.");
         _STRUCT_MCONTEXT machineContext;
         if(ksmachexc_i_fetchMachineState(exceptionMessage.thread.name, &machineContext))

--- a/KSCrash/KSCrash/KSCrashSentry_MachException.h
+++ b/KSCrash/KSCrash/KSCrashSentry_MachException.h
@@ -44,7 +44,7 @@ extern "C" {
  *
  * @param context Contextual information for the crash handler.
  *
- * @param onCrash Called when a crash occurs.
+ * @return true if installation was succesful.
  */
 bool kscrashsentry_installMachHandler(KSCrash_SentryContext* context);
 

--- a/KSCrash/KSCrash/KSCrashSentry_NSException.h
+++ b/KSCrash/KSCrash/KSCrashSentry_NSException.h
@@ -44,7 +44,7 @@ extern "C" {
  *
  * @param context The crash context to fill out when a crash occurs.
  *
- * @param onCrash Called when a crash occurs.
+ * @return true if installation was succesful.
  */
 bool kscrashsentry_installNSExceptionHandler(KSCrash_SentryContext* context);
 

--- a/KSCrash/KSCrash/KSCrashSentry_NSException.m
+++ b/KSCrash/KSCrash/KSCrashSentry_NSException.m
@@ -67,15 +67,17 @@ void ksnsexc_i_handleException(NSException* exception)
     KSLOG_DEBUG(@"Trapped exception %@", exception);
     if(g_installed)
     {
+        bool wasHandlingCrash = g_context->handlingCrash;
+        kscrashsentry_beginHandlingCrash(g_context);
+
         KSLOG_DEBUG(@"Exception handler is installed. Continuing exception handling.");
 
-        if(g_context->handlingCrash)
+        if(wasHandlingCrash)
         {
             KSLOG_INFO(@"Detected crash in the crash reporter. Restoring original handlers.");
             g_context->crashedDuringCrashHandling = true;
             kscrashsentry_uninstall(KSCrashTypeAll);
         }
-        g_context->handlingCrash = true;
 
         KSLOG_DEBUG(@"Suspending all threads.");
         kscrashsentry_suspendThreads();

--- a/KSCrash/KSCrash/KSCrashSentry_NSException.m
+++ b/KSCrash/KSCrash/KSCrashSentry_NSException.m
@@ -93,9 +93,9 @@ void ksnsexc_i_handleException(NSException* exception)
         g_context->offendingThread = mach_thread_self();
         g_context->registersAreValid = false;
         g_context->NSException.name = strdup([[exception name] UTF8String]);
-        g_context->NSException.reason = strdup([[exception reason] UTF8String]);
-        g_context->NSException.stackTrace = callstack;
-        g_context->NSException.stackTraceLength = (int)numFrames;
+        g_context->crashReason = strdup([[exception reason] UTF8String]);
+        g_context->stackTrace = callstack;
+        g_context->stackTraceLength = (int)numFrames;
 
 
         KSLOG_DEBUG(@"Calling main crash handler.");

--- a/KSCrash/KSCrash/KSCrashSentry_Private.h
+++ b/KSCrash/KSCrash/KSCrashSentry_Private.h
@@ -28,6 +28,10 @@
 #ifndef HDR_KSCrashSentry_Private_h
 #define HDR_KSCrashSentry_Private_h
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 
 /** Suspend all non-reserved threads.
  *
@@ -43,5 +47,17 @@ void kscrashsentry_suspendThreads(void);
  */
 void kscrashsentry_resumeThreads(void);
 
+/** Prepare the context for handling a new crash.
+ */
+void kscrashsentry_beginHandlingCrash(KSCrash_SentryContext* context);
+
+/** Clear a crash sentry context.
+ */
+void kscrashsentry_clearContext(KSCrash_SentryContext* context);
+
+    
+#ifdef __cplusplus
+}
+#endif
 
 #endif // HDR_KSCrashSentry_Private_h

--- a/KSCrash/KSCrash/KSCrashSentry_Signal.c
+++ b/KSCrash/KSCrash/KSCrashSentry_Signal.c
@@ -84,18 +84,20 @@ void kssighndl_i_handleSignal(int sigNum,
     KSLOG_DEBUG("Trapped signal %d", sigNum);
     if(g_installed)
     {
+        bool wasHandlingCrash = g_context->handlingCrash;
+        kscrashsentry_beginHandlingCrash(g_context);
+
         KSLOG_DEBUG("Signal handler is installed. Continuing signal handling.");
 
         KSLOG_DEBUG("Suspending all threads.");
         kscrashsentry_suspendThreads();
 
-        if(g_context->handlingCrash)
+        if(wasHandlingCrash)
         {
             KSLOG_INFO("Detected crash in the crash reporter. Restoring original handlers.");
             g_context->crashedDuringCrashHandling = true;
             kscrashsentry_uninstall(KSCrashTypeAsyncSafe);
         }
-        g_context->handlingCrash = true;
 
 
         KSLOG_DEBUG("Filling out context.");

--- a/KSCrash/KSCrash/KSCrashSentry_Signal.h
+++ b/KSCrash/KSCrash/KSCrashSentry_Signal.h
@@ -44,8 +44,6 @@ extern "C" {
  *
  * @param context The crash context to fill out when a crash occurs.
  *
- * @param onCrash Called when a crash occurs.
- *
  * @return true if installation was succesful.
  */
 bool kscrashsentry_installSignalHandler(KSCrash_SentryContext* context);

--- a/KSCrash/KSCrash/KSCrashSentry_User.c
+++ b/KSCrash/KSCrash/KSCrashSentry_User.c
@@ -1,0 +1,85 @@
+//
+//  KSCrashSentry_User.c
+//  KSCrash
+//
+//  Created by Karl Stenerud on 6/4/13.
+//  Copyright (c) 2013 Karl Stenerud. All rights reserved.
+//
+
+#include "KSCrashSentry_User.h"
+#include "KSCrashSentry_Private.h"
+
+//#define KSLogger_LocalLevel TRACE
+#include "KSLogger.h"
+
+#include <execinfo.h>
+#include <mach/mach.h>
+#include <stdlib.h>
+
+
+/** Context to fill with crash information. */
+static KSCrash_SentryContext* g_context;
+
+
+bool kscrashsentry_installUserExceptionHandler(KSCrash_SentryContext* const context)
+{
+    KSLOG_DEBUG("Installing user exception handler.");
+    g_context = context;
+    return true;
+}
+
+void kscrashsentry_uninstallUserExceptionHandler(void)
+{
+    KSLOG_DEBUG("Uninstalling user exception handler.");
+    g_context = NULL;
+}
+
+void kscrashsentry_reportUserException(const char* name,
+                                       const char* reason,
+                                       const char* lineOfCode,
+                                       const char** stackTrace,
+                                       size_t stackTraceCount,
+                                       bool terminateProgram)
+{
+    if(g_context != NULL)
+    {
+        KSLOG_DEBUG("Suspending all threads");
+        kscrashsentry_suspendThreads();
+
+        KSLOG_DEBUG("Fetching call stack.");
+        int callstackCount = 100;
+        uintptr_t callstack[callstackCount];
+        callstackCount = backtrace((void**)callstack, callstackCount);
+        if(callstackCount <= 0)
+        {
+            KSLOG_ERROR("backtrace() returned call stack length of %d", callstackCount);
+            callstackCount = 0;
+        }
+
+        KSLOG_DEBUG("Filling out context.");
+        g_context->crashType = KSCrashTypeUserReported;
+        g_context->offendingThread = mach_thread_self();
+        g_context->registersAreValid = false;
+        g_context->crashReason = reason;
+        g_context->stackTrace = callstack;
+        g_context->stackTraceLength = callstackCount;
+        g_context->userException.name = name;
+        g_context->userException.lineOfCode = lineOfCode;
+        g_context->userException.customStackTrace = stackTrace;
+        g_context->userException.customStackTraceLength = (int)stackTraceCount;
+
+        KSLOG_DEBUG("Calling main crash handler.");
+        g_context->onCrash();
+
+        if(terminateProgram)
+        {
+            kscrashsentry_uninstall(KSCrashTypeAll);
+            kscrashsentry_resumeThreads();
+            abort();
+        }
+        else
+        {
+            kscrashsentry_resumeThreads();
+        }
+    }
+}

--- a/KSCrash/KSCrash/KSCrashSentry_User.c
+++ b/KSCrash/KSCrash/KSCrashSentry_User.c
@@ -43,6 +43,8 @@ void kscrashsentry_reportUserException(const char* name,
 {
     if(g_context != NULL)
     {
+        kscrashsentry_beginHandlingCrash(g_context);
+
         KSLOG_DEBUG("Suspending all threads");
         kscrashsentry_suspendThreads();
 
@@ -79,6 +81,7 @@ void kscrashsentry_reportUserException(const char* name,
         }
         else
         {
+            kscrashsentry_clearContext(g_context);
             kscrashsentry_resumeThreads();
         }
     }

--- a/KSCrash/KSCrash/KSCrashSentry_User.h
+++ b/KSCrash/KSCrash/KSCrashSentry_User.h
@@ -1,0 +1,64 @@
+//
+//  KSCrashSentry_User.h
+//  KSCrash
+//
+//  Created by Karl Stenerud on 6/4/13.
+//  Copyright (c) 2013 Karl Stenerud. All rights reserved.
+//
+
+#ifndef HDR_KSCrashSentry_User_h
+#define HDR_KSCrashSentry_User_h
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#include "KSCrashSentry.h"
+
+#include <signal.h>
+#include <stdbool.h>
+
+
+/** Install the user exception handler.
+ *
+ * @param context Contextual information for the crash handler.
+ *
+ * @return true if installation was succesful.
+ */
+bool kscrashsentry_installUserExceptionHandler(KSCrash_SentryContext* context);
+
+/** Uninstall the user exception handler.
+ */
+void kscrashsentry_uninstallUserExceptionHandler(void);
+
+
+/** Report a custom, user defined exception.
+ * If terminateProgram is true, all sentries will be uninstalled and the application will
+ * terminate with an abort().
+ *
+ * @param name The exception name (for namespacing exception types).
+ *
+ * @param reason A description of why the exception occurred.
+ *
+ * @param lineOfCode A copy of the offending line of code (NULL = ignore).
+ *
+ * @param stackTrace An array of strings representing the call stack leading to the exception.
+ *
+ * @param stackTraceCount The length of the stack trace array.
+ *
+ * @param terminateProgram If true, do not return from this function call. Terminate the program instead.
+ */
+void kscrashsentry_reportUserException(const char* name,
+                                       const char* reason,
+                                       const char* lineOfCode,
+                                       const char** stackTrace,
+                                       size_t stackTraceCount,
+                                       bool terminateProgram);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // HDR_KSCrashSentry_User_h

--- a/KSCrash/KSCrash/KSCrashSentry_User.h
+++ b/KSCrash/KSCrash/KSCrashSentry_User.h
@@ -45,7 +45,7 @@ void kscrashsentry_uninstallUserExceptionHandler(void);
  *
  * @param stackTrace An array of strings representing the call stack leading to the exception.
  *
- * @param stackTraceCount The length of the stack trace array.
+ * @param stackTraceCount The length of the stack trace array (0 = ignore).
  *
  * @param terminateProgram If true, do not return from this function call. Terminate the program instead.
  */

--- a/KSCrash/KSCrash/KSMach.h
+++ b/KSCrash/KSCrash/KSMach.h
@@ -40,7 +40,19 @@ extern "C" {
 #include <mach/mach.h>
 #include <mach-o/dyld.h>
 #include <stdbool.h>
+#include <pthread.h>
 #include <sys/ucontext.h>
+
+
+// ============================================================================
+#pragma mark - Initialization -
+// ============================================================================
+
+/** Initializes KSMach.
+ * Some functions (currently only ksmach_pthreadFromMachThread) require
+ * initialization before use.
+ */
+void ksmach_init(void);
 
 
 // ============================================================================
@@ -220,10 +232,23 @@ uint64_t ksmach_exceptionRegisterValue(const _STRUCT_MCONTEXT* machineContext,
  */
 int ksmach_stackGrowDirection(void);
 
-/** Get the name of a thread's dispatch queue. Internally, a queue name will
+/** Get a thread's name. Internally, a thread name will
  * never be more than 64 characters long.
  *
  * @param thread The thread whose name to get.
+ *
+ * @oaram buffer Buffer to hold the name.
+ *
+ * @param bufLength The length of the buffer.
+ *
+ * @return true if a name was found.
+ */
+bool ksmach_getThreadName(const thread_t thread, char* const buffer, size_t bufLength);
+
+/** Get the name of a thread's dispatch queue. Internally, a queue name will
+ * never be more than 64 characters long.
+ *
+ * @param thread The thread whose queue name to get.
  *
  * @oaram buffer Buffer to hold the name.
  *
@@ -273,6 +298,22 @@ uintptr_t ksmach_firstCmdAfterHeader(const struct mach_header* header);
 // ============================================================================
 #pragma mark - Utility -
 // ============================================================================
+
+/** Get a mach thread's corresponding posix thread.
+ *
+ * @param thread The mach thread.
+ *
+ * @return The corresponding posix thread, or 0 if an error occurred.
+ */
+pthread_t ksmach_pthreadFromMachThread(const thread_t thread);
+
+/** Get a posix thread's corresponding mach thread.
+ *
+ * @param pthread The posix thread.
+ *
+ * @return The corresponding mach thread, or 0 if an error occurred.
+ */
+thread_t ksmach_machThreadFromPThread(const pthread_t pthread);
 
 /** Suspend all threads except for the current one.
  *

--- a/KSCrash/KSCrash/KSString.c
+++ b/KSCrash/KSCrash/KSString.c
@@ -27,6 +27,7 @@
 
 #include "KSString.h"
 #include <string.h>
+#include <stdlib.h>
 
 
 // Compiler hints for "if" statements
@@ -166,4 +167,20 @@ bool ksstring_extractHexValue(const char* string,
         }
     }
     return false;
+}
+
+void ksstring_replace(const char** dest, const char* replacement)
+{
+    if(*dest != NULL)
+    {
+        free((void*)*dest);
+    }
+    if(replacement == NULL)
+    {
+        *dest = NULL;
+    }
+    else
+    {
+        *dest = strdup(replacement);
+    }
 }

--- a/KSCrash/KSCrash/KSString.h
+++ b/KSCrash/KSCrash/KSString.h
@@ -63,6 +63,17 @@ bool ksstring_extractHexValue(const char* string,
                               size_t stringLength,
                               uint64_t* result);
 
+/** Replace a string with another string.
+ * If dest points to a non-null, it will be freed.
+ * If replacement is null, dest will point to null.
+ * If replacement is not null, dest will point to a copy of replacement,
+ * which the user is responsible for freeing.
+ *
+ * @param dest Pointer to the string to replace.
+ *
+ * @param replacement The string to replace with.
+ */
+void ksstring_replace(const char** dest, const char* replacement);
     
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Added support for user-defined exceptions and stack traces.

With this new API, users can report their own exceptions and provide custom stack traces. This is particularly useful for capturing exceptions and stack traces from scripting languages.

In an Apple-style report, it would look like this:

```
Exception Type:  EXC_CRASH (SIGABRT)
Exception Codes: 0x00000000 at 0x00000000
Crashed Thread:  0

Application Specific Information:
*** Terminating app due to uncaught exception 'Script Error', reason: 'fragment is not defined'

Custom Backtrace:
Line: string.append(fragment)
Printer.script, line 174: in function assembleComponents
Printer.script, line 209: in function print
Main.script, line 10: in function initialize


Thread 0 name:  Dispatch queue: com.apple.main-thread
Thread 0 Crashed:
0   Crash-Tester                    0x00049c61 0x1000 + 298081 (kscrashsentry_reportUserException + 145)
1   Crash-Tester                    0x00035192 0x1000 + 213394 (kscrash_reportUserException + 98)
2   Crash-Tester                    0x0000bbbf 0x1000 + 43967 (-[KSCrash reportUserException:reason:lineOfCode:stackTrace:terminateProgram:] + 399)
3   Crash-Tester                    0x0000a5ec 0x1000 + 38380 (-[Crasher userDefinedCrash] + 252)
4   Crash-Tester                    0x00008ae8 0x1000 + 31464 (__32-[AppDelegate(UI) crashCommands]_block_invoke463 + 72)
5   Crash-Tester                    0x00008da3 0x1000 + 32163 (-[CommandEntry executeWithViewController:] + 67)
6   Crash-Tester                    0x0000948a 0x1000 + 33930 (-[CommandTVC tableView:didSelectRowAtIndexPath:] + 154)
7   UIKit                           0x0016a285 0xaf000 + 766597 (-[UITableView _selectRowAtIndexPath:animated:scrollPosition:notifyDelegate:] + 1194)
8   UIKit                           0x0016a4ed 0xaf000 + 767213 (-[UITableView _userSelectRowAtPendingSelectionIndexPath:] + 201)
9   Foundation                      0x00b745b3 0xb69000 + 46515 (__NSFireDelayedPerform + 380)
10  CoreFoundation                  0x01e8e376 0x1e43000 + 308086 (__CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ + 22)
11  CoreFoundation                  0x01e8de06 0x1e43000 + 306694 (__CFRunLoopDoTimer + 534)
12  CoreFoundation                  0x01e75a82 0x1e43000 + 207490 (__CFRunLoopRun + 1810)
13  CoreFoundation                  0x01e74f44 0x1e43000 + 204612 (CFRunLoopRunSpecific + 276)
14  CoreFoundation                  0x01e74e1b 0x1e43000 + 204315 (CFRunLoopRunInMode + 123)
15  GraphicsServices                0x01e297e3 0x1e21000 + 34787 (GSEventRunModal + 88)
16  GraphicsServices                0x01e29668 0x1e21000 + 34408 (GSEventRun + 104)
17  UIKit                           0x000baffc 0xaf000 + 49148 (UIApplicationMain + 1211)
18  Crash-Tester                    0x000024ba 0x1000 + 5306 (main + 170)
19  Crash-Tester                    0x000023c5 0x1000 + 5061 (start + 53)
```

Note: Commit https://github.com/mindsnacks/KSCrash/commit/d4aa56867a97146fb4ca9051f44f980d28dc055e is actually merged from upstream.

TODO:
- [x] Allow empty custom stack trace

Review:
- [x] @JaviSoto 
- [ ] @tonycosentini 
