### PR TITLE
[FINAL] Added C++ exception handling.

### DIFF
--- a/Example-Apps/Crash-Tester/AppDelegate+UI.m
+++ b/Example-Apps/Crash-Tester/AppDelegate+UI.m
@@ -496,9 +496,17 @@ MAKE_CATEGORIES_LOADABLE(AppDelegate_UI)
                      accessoryType:UITableViewCellAccessoryNone
                              block:^(__unused UIViewController* controller)
       {
-          [blockSelf.crasher throwException];
+          [blockSelf.crasher throwUncaughtNSException];
       }]];
     
+    [commands addObject:
+     [CommandEntry commandWithName:@"C++ Exception"
+                     accessoryType:UITableViewCellAccessoryNone
+                             block:^(__unused UIViewController* controller)
+      {
+          [blockSelf.crasher throwUncaughtCPPException];
+      }]];
+
     [commands addObject:
      [CommandEntry commandWithName:@"Bad Pointer"
                      accessoryType:UITableViewCellAccessoryNone

--- a/Example-Apps/Crash-Tester/Crasher.h
+++ b/Example-Apps/Crash-Tester/Crasher.h
@@ -8,7 +8,7 @@
 
 @interface Crasher : NSObject
 
-- (void) throwException;
+- (void) throwUncaughtNSException;
 
 - (void) dereferenceBadPointer;
 
@@ -39,5 +39,7 @@
 - (void) pthreadAPICrash;
 
 - (void) userDefinedCrash;
+
+- (void) throwUncaughtCPPException;
 
 @end

--- a/Example-Apps/Crash-Tester/Crasher.mm
+++ b/Example-Apps/Crash-Tester/Crasher.mm
@@ -8,6 +8,7 @@
 #import "ARCSafe_MemMgmt.h"
 #import <KSCrash/KSCrash.h>
 #import <pthread.h>
+#import <exception>
 
 @interface MyClass: NSObject @end
 @implementation MyClass @end
@@ -235,9 +236,21 @@ int g_crasher_denominator = 0;
                                  terminateProgram:NO];
 }
 
+
+class MyException: public std::exception
+{
+public:
+    virtual const char* what() const noexcept;
+};
+
+const char* MyException::what() const noexcept
+{
+    return "Something bad happened...";
+}
+
 - (void) throwUncaughtCPPException
 {
-    throw 20;
+    throw MyException();
 }
 
 @end

--- a/Example-Apps/Crash-Tester/Crasher.mm
+++ b/Example-Apps/Crash-Tester/Crasher.mm
@@ -67,7 +67,7 @@
 int* g_crasher_null_ptr = NULL;
 int g_crasher_denominator = 0;
 
-- (void) throwException
+- (void) throwUncaughtNSException
 {
     id data = [NSArray arrayWithObject:@"Hello World"];
     [(NSDictionary*)data objectForKey:0];
@@ -90,7 +90,13 @@ int g_crasher_denominator = 0;
     
     // Random data
     void* pointers[] = {NULL, NULL, NULL};
-    void* randomData[] = {"a","b",pointers,"d","e","f"};
+    void* randomData[] = {
+        (void*)"a",
+        (void*)"b",
+        (void*)pointers,
+        (void*)"d",
+        (void*)"e",
+        (void*)"f"};
     
     // A corrupted/under-retained/re-used piece of memory
     struct {void* isa;} corruptObj = {randomData};
@@ -227,6 +233,11 @@ int g_crasher_denominator = 0;
                                        lineOfCode:lineOfCode
                                        stackTrace:stackTrace
                                  terminateProgram:NO];
+}
+
+- (void) throwUncaughtCPPException
+{
+    throw 20;
 }
 
 @end

--- a/Example-Apps/Example-Apps.xcodeproj/project.pbxproj
+++ b/Example-Apps/Example-Apps.xcodeproj/project.pbxproj
@@ -50,7 +50,7 @@
 		CB1C616116E96BF90088122E /* Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = CB1C616016E96BF90088122E /* Icon.png */; };
 		CB1C616816E96C160088122E /* AppDelegate+UI.m in Sources */ = {isa = PBXBuildFile; fileRef = CB1C616316E96C150088122E /* AppDelegate+UI.m */; };
 		CB1C616916E96C160088122E /* CommandTVC.m in Sources */ = {isa = PBXBuildFile; fileRef = CB1C616616E96C160088122E /* CommandTVC.m */; };
-		CB1C616C16E96C270088122E /* Crasher.m in Sources */ = {isa = PBXBuildFile; fileRef = CB1C616B16E96C270088122E /* Crasher.m */; };
+		CB1C616C16E96C270088122E /* Crasher.mm in Sources */ = {isa = PBXBuildFile; fileRef = CB1C616B16E96C270088122E /* Crasher.mm */; };
 		CB1C616E16E96C680088122E /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB1C610C16E958040088122E /* SystemConfiguration.framework */; };
 		CB1C616F16E96C680088122E /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB1C610A16E958000088122E /* MessageUI.framework */; };
 		CB1C617016E96C6B0088122E /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CB1C610816E957FB0088122E /* libz.dylib */; };
@@ -77,7 +77,7 @@
 		CB1C610816E957FB0088122E /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
 		CB1C610A16E958000088122E /* MessageUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
 		CB1C610C16E958040088122E /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
-		CB1C610E16E958130088122E /* KSCrash.framework */ = {isa = PBXFileReference; lastKnownFileType = file; name = KSCrash.framework; path = "../KSCrash/build/Release-iphoneos/KSCrash.framework"; sourceTree = "<group>"; };
+		CB1C610E16E958130088122E /* KSCrash.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = KSCrash.framework; path = "../KSCrash/build/Release-iphoneos/KSCrash.framework"; sourceTree = "<group>"; };
 		CB1C611416E959C70088122E /* Advanced-Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Advanced-Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB1C611A16E959C70088122E /* Advanced-Example-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Advanced-Example-Info.plist"; sourceTree = "<group>"; };
 		CB1C611C16E959C70088122E /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -111,7 +111,7 @@
 		CB1C616616E96C160088122E /* CommandTVC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CommandTVC.m; sourceTree = "<group>"; };
 		CB1C616716E96C160088122E /* Configuration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Configuration.h; sourceTree = "<group>"; };
 		CB1C616A16E96C270088122E /* Crasher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Crasher.h; sourceTree = "<group>"; };
-		CB1C616B16E96C270088122E /* Crasher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Crasher.m; sourceTree = "<group>"; };
+		CB1C616B16E96C270088122E /* Crasher.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Crasher.mm; sourceTree = "<group>"; };
 		CB1C616D16E96C2F0088122E /* LoadableCategory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoadableCategory.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -264,7 +264,7 @@
 				CB1C616616E96C160088122E /* CommandTVC.m */,
 				CB1C616716E96C160088122E /* Configuration.h */,
 				CB1C616A16E96C270088122E /* Crasher.h */,
-				CB1C616B16E96C270088122E /* Crasher.m */,
+				CB1C616B16E96C270088122E /* Crasher.mm */,
 				CB1C616D16E96C2F0088122E /* LoadableCategory.h */,
 				CB1C614616E96B4F0088122E /* Supporting Files */,
 			);
@@ -437,7 +437,7 @@
 				CB1C615016E96B4F0088122E /* AppDelegate.m in Sources */,
 				CB1C616816E96C160088122E /* AppDelegate+UI.m in Sources */,
 				CB1C616916E96C160088122E /* CommandTVC.m in Sources */,
-				CB1C616C16E96C270088122E /* Crasher.m in Sources */,
+				CB1C616C16E96C270088122E /* Crasher.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -661,7 +661,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Crash-Tester/Crash-Tester-Prefix.pch";
 				INFOPLIST_FILE = "Crash-Tester/Crash-Tester-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
@@ -676,7 +676,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Crash-Tester/Crash-Tester-Prefix.pch";
 				INFOPLIST_FILE = "Crash-Tester/Crash-Tester-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
@@ -702,6 +702,7 @@
 				CB1C610716E9579A0088122E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		CB1C613016E959C70088122E /* Build configuration list for PBXNativeTarget "Advanced-Example" */ = {
 			isa = XCConfigurationList;
@@ -710,6 +711,7 @@
 				CB1C613216E959C70088122E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		CB1C615D16E96B4F0088122E /* Build configuration list for PBXNativeTarget "Crash-Tester" */ = {
 			isa = XCConfigurationList;
@@ -718,6 +720,7 @@
 				CB1C615F16E96B4F0088122E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/KSCrash/KSCrash.xcodeproj/project.pbxproj
+++ b/KSCrash/KSCrash.xcodeproj/project.pbxproj
@@ -366,6 +366,9 @@
 		CB5A5B4716C718C500DC1D2D /* KSCrashCallCompletion.m in Sources */ = {isa = PBXBuildFile; fileRef = CB5A5B4216C718C400DC1D2D /* KSCrashCallCompletion.m */; };
 		CB5A5B4816C718C500DC1D2D /* KSCrashCallCompletion.m in Sources */ = {isa = PBXBuildFile; fileRef = CB5A5B4216C718C400DC1D2D /* KSCrashCallCompletion.m */; };
 		CB5A5B4916C7589400DC1D2D /* NSDictionary+Merge.h in Headers */ = {isa = PBXBuildFile; fileRef = 39DA84F4161978D7001E7F79 /* NSDictionary+Merge.h */; };
+		CB5C51781766711D00A05F0C /* KSCrashType.h in Headers */ = {isa = PBXBuildFile; fileRef = CB5C51771766702000A05F0C /* KSCrashType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CB5C51791766713000A05F0C /* KSCrashType.h in Headers */ = {isa = PBXBuildFile; fileRef = CB5C51771766702000A05F0C /* KSCrashType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CB5C517A1766714A00A05F0C /* KSCrashType.h in Headers */ = {isa = PBXBuildFile; fileRef = CB5C51771766702000A05F0C /* KSCrashType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CB775560169F402700EA90A5 /* libKSCrashLib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 39DA35C616184338009EB332 /* libKSCrashLib.a */; };
 		CB78E8B5169C934100C39B02 /* KSObjCApple.h in Headers */ = {isa = PBXBuildFile; fileRef = CB78E8B4169C934100C39B02 /* KSObjCApple.h */; };
 		CB78E8B6169C934100C39B02 /* KSObjCApple.h in Headers */ = {isa = PBXBuildFile; fileRef = CB78E8B4169C934100C39B02 /* KSObjCApple.h */; };
@@ -603,6 +606,7 @@
 		CB5A5B3A16C6650E00DC1D2D /* NSError+SimpleConstructor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSError+SimpleConstructor.m"; sourceTree = "<group>"; };
 		CB5A5B4116C718C400DC1D2D /* KSCrashCallCompletion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSCrashCallCompletion.h; sourceTree = "<group>"; };
 		CB5A5B4216C718C400DC1D2D /* KSCrashCallCompletion.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSCrashCallCompletion.m; sourceTree = "<group>"; };
+		CB5C51771766702000A05F0C /* KSCrashType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KSCrashType.h; sourceTree = "<group>"; };
 		CB78E8B4169C934100C39B02 /* KSObjCApple.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSObjCApple.h; sourceTree = "<group>"; };
 		CB78E8B9169C94DA00C39B02 /* KSMachApple.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSMachApple.h; sourceTree = "<group>"; };
 		CB7C753D16CD5DA200227870 /* KSCrashInstallation+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "KSCrashInstallation+Private.h"; sourceTree = "<group>"; };
@@ -908,6 +912,7 @@
 				39DA83A21618450A001E7F79 /* KSCrashReportWriter.h */,
 				39DA83AC1618450A001E7F79 /* KSCrashState.c */,
 				39DA83AD1618450A001E7F79 /* KSCrashState.h */,
+				CB5C51771766702000A05F0C /* KSCrashType.h */,
 				39DA83AE1618450A001E7F79 /* KSSystemInfo.h */,
 				39DA83AF1618450A001E7F79 /* KSSystemInfo.m */,
 				39DA83B01618450A001E7F79 /* KSSystemInfoC.h */,
@@ -1018,11 +1023,12 @@
 				39DA830916184487001E7F79 /* KSCrashReportSinkStandard.h in Headers */,
 				2122BBCF16F185120056D11C /* KSCrashReportSinkTakanashi.h in Headers */,
 				39DA82C416184456001E7F79 /* KSCrashReportStore.h in Headers */,
-				39DA836B161844FF001E7F79 /* KSJSONCodecObjC.h in Headers */,
 				397A7C87162266480096E287 /* KSCrashReportFields.h in Headers */,
 				39DA84F6161978D7001E7F79 /* NSDictionary+Merge.h in Headers */,
 				39DA8359161844FF001E7F79 /* ARCSafe_MemMgmt.h in Headers */,
 				39DA831A16184492001E7F79 /* Container+DeepSearch.h in Headers */,
+				39DA836B161844FF001E7F79 /* KSJSONCodecObjC.h in Headers */,
+				CB5C51781766711D00A05F0C /* KSCrashType.h in Headers */,
 				39DA835B161844FF001E7F79 /* KSArchSpecific.h in Headers */,
 				39DA8361161844FF001E7F79 /* KSBacktrace.h in Headers */,
 				39DA835D161844FF001E7F79 /* KSBacktrace_Private.h in Headers */,
@@ -1092,6 +1098,7 @@
 				39DA830616184487001E7F79 /* KSCrashReportSinkQuincyHockey.h in Headers */,
 				39DA830A16184487001E7F79 /* KSCrashReportSinkStandard.h in Headers */,
 				2122BBD016F185120056D11C /* KSCrashReportSinkTakanashi.h in Headers */,
+				CB5C517A1766714A00A05F0C /* KSCrashType.h in Headers */,
 				39DA836C161844FF001E7F79 /* KSJSONCodecObjC.h in Headers */,
 				397A7C88162266480096E287 /* KSCrashReportFields.h in Headers */,
 				39DA835A161844FF001E7F79 /* ARCSafe_MemMgmt.h in Headers */,
@@ -1160,6 +1167,7 @@
 				CB0AA141167EC480006EAB99 /* KSCrashReportFilterBasic.h in Headers */,
 				CB0AA143167EC485006EAB99 /* KSCrashReportFilterJSON.h in Headers */,
 				CB0AA145167EC485006EAB99 /* KSCrashReportSinkConsole.h in Headers */,
+				CB5C51791766713000A05F0C /* KSCrashType.h in Headers */,
 				CB0AA11D167EC470006EAB99 /* KSJSONCodecObjC.h in Headers */,
 				CB0AA0FE167EC460006EAB99 /* KSCrashC.h in Headers */,
 				CB0AA0FF167EC460006EAB99 /* KSCrashContext.h in Headers */,

--- a/KSCrash/KSCrash.xcodeproj/project.pbxproj
+++ b/KSCrash/KSCrash.xcodeproj/project.pbxproj
@@ -244,9 +244,9 @@
 		CB05EC6617623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c in Sources */ = {isa = PBXBuildFile; fileRef = CB05EC6517623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c */; };
 		CB05EC6717623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c in Sources */ = {isa = PBXBuildFile; fileRef = CB05EC6517623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c */; };
 		CB05EC6817623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c in Sources */ = {isa = PBXBuildFile; fileRef = CB05EC6517623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c */; };
-		CB05EC8A176292EA0095353E /* KSCrashSentry_CPPException.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CB05EC5D17623AE30095353E /* KSCrashSentry_CPPException.cpp */; };
-		CB05EC8B176292EB0095353E /* KSCrashSentry_CPPException.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CB05EC5D17623AE30095353E /* KSCrashSentry_CPPException.cpp */; };
-		CB05EC8C176292EB0095353E /* KSCrashSentry_CPPException.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CB05EC5D17623AE30095353E /* KSCrashSentry_CPPException.cpp */; };
+		CB05EC8A176292EA0095353E /* KSCrashSentry_CPPException.mm in Sources */ = {isa = PBXBuildFile; fileRef = CB05EC5D17623AE30095353E /* KSCrashSentry_CPPException.mm */; };
+		CB05EC8B176292EB0095353E /* KSCrashSentry_CPPException.mm in Sources */ = {isa = PBXBuildFile; fileRef = CB05EC5D17623AE30095353E /* KSCrashSentry_CPPException.mm */; };
+		CB05EC8C176292EB0095353E /* KSCrashSentry_CPPException.mm in Sources */ = {isa = PBXBuildFile; fileRef = CB05EC5D17623AE30095353E /* KSCrashSentry_CPPException.mm */; };
 		CB0AA0F4167EC43E006EAB99 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = CB0AA0F2167EC43E006EAB99 /* InfoPlist.strings */; };
 		CB0AA0FD167EC460006EAB99 /* KSCrashC.c in Sources */ = {isa = PBXBuildFile; fileRef = 39DA839D1618450A001E7F79 /* KSCrashC.c */; };
 		CB0AA0FE167EC460006EAB99 /* KSCrashC.h in Headers */ = {isa = PBXBuildFile; fileRef = 39DA839E1618450A001E7F79 /* KSCrashC.h */; };
@@ -586,7 +586,7 @@
 		39DA84F4161978D7001E7F79 /* NSDictionary+Merge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.objj.h; path = "NSDictionary+Merge.h"; sourceTree = "<group>"; };
 		39DA84F5161978D7001E7F79 /* NSDictionary+Merge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+Merge.m"; sourceTree = "<group>"; };
 		39DA84FB16198753001E7F79 /* NSDictionary+Merge_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+Merge_Tests.m"; sourceTree = "<group>"; };
-		CB05EC5D17623AE30095353E /* KSCrashSentry_CPPException.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KSCrashSentry_CPPException.cpp; sourceTree = "<group>"; };
+		CB05EC5D17623AE30095353E /* KSCrashSentry_CPPException.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = KSCrashSentry_CPPException.mm; sourceTree = "<group>"; };
 		CB05EC6117623AFF0095353E /* KSCrashSentry_CPPException.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSCrashSentry_CPPException.h; sourceTree = "<group>"; };
 		CB05EC6517623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = KSCrashSentry_CPPExceptionDisabled.c; sourceTree = "<group>"; };
 		CB0AA0EE167EC43E006EAB99 /* KSCrashLite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KSCrashLite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -886,7 +886,7 @@
 			children = (
 				39DA83AA1618450A001E7F79 /* KSCrashSentry.c */,
 				39DA83AB1618450A001E7F79 /* KSCrashSentry.h */,
-				CB05EC5D17623AE30095353E /* KSCrashSentry_CPPException.cpp */,
+				CB05EC5D17623AE30095353E /* KSCrashSentry_CPPException.mm */,
 				CB05EC6117623AFF0095353E /* KSCrashSentry_CPPException.h */,
 				CB05EC6517623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c */,
 				39D329DA16765AD500D989DC /* KSCrashSentry_Deadlock.h */,
@@ -1478,7 +1478,7 @@
 				2193ACC616F19D690016EA5F /* KSCrashInstallationTakanashi.m in Sources */,
 				CBCED88D175E567F00BF56F0 /* KSCrashSentry_User.c in Sources */,
 				CB05EC6617623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c in Sources */,
-				CB05EC8A176292EA0095353E /* KSCrashSentry_CPPException.cpp in Sources */,
+				CB05EC8A176292EA0095353E /* KSCrashSentry_CPPException.mm in Sources */,
 				CB5C51881767639400A05F0C /* KSCrashType.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1545,7 +1545,7 @@
 				2193ACC716F19D690016EA5F /* KSCrashInstallationTakanashi.m in Sources */,
 				CBCED88F175E567F00BF56F0 /* KSCrashSentry_User.c in Sources */,
 				CB05EC6817623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c in Sources */,
-				CB05EC8C176292EB0095353E /* KSCrashSentry_CPPException.cpp in Sources */,
+				CB05EC8C176292EB0095353E /* KSCrashSentry_CPPException.mm in Sources */,
 				CB5C518A1767639400A05F0C /* KSCrashType.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1642,7 +1642,7 @@
 				CB1B377316D74F3C00FFFCEA /* KSCString.m in Sources */,
 				CBCED88E175E567F00BF56F0 /* KSCrashSentry_User.c in Sources */,
 				CB05EC6717623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c in Sources */,
-				CB05EC8B176292EB0095353E /* KSCrashSentry_CPPException.cpp in Sources */,
+				CB05EC8B176292EB0095353E /* KSCrashSentry_CPPException.mm in Sources */,
 				CB5C51891767639400A05F0C /* KSCrashType.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/KSCrash/KSCrash.xcodeproj/project.pbxproj
+++ b/KSCrash/KSCrash.xcodeproj/project.pbxproj
@@ -369,6 +369,9 @@
 		CB5C51781766711D00A05F0C /* KSCrashType.h in Headers */ = {isa = PBXBuildFile; fileRef = CB5C51771766702000A05F0C /* KSCrashType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CB5C51791766713000A05F0C /* KSCrashType.h in Headers */ = {isa = PBXBuildFile; fileRef = CB5C51771766702000A05F0C /* KSCrashType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CB5C517A1766714A00A05F0C /* KSCrashType.h in Headers */ = {isa = PBXBuildFile; fileRef = CB5C51771766702000A05F0C /* KSCrashType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CB5C51881767639400A05F0C /* KSCrashType.c in Sources */ = {isa = PBXBuildFile; fileRef = CB5C51871767639400A05F0C /* KSCrashType.c */; };
+		CB5C51891767639400A05F0C /* KSCrashType.c in Sources */ = {isa = PBXBuildFile; fileRef = CB5C51871767639400A05F0C /* KSCrashType.c */; };
+		CB5C518A1767639400A05F0C /* KSCrashType.c in Sources */ = {isa = PBXBuildFile; fileRef = CB5C51871767639400A05F0C /* KSCrashType.c */; };
 		CB775560169F402700EA90A5 /* libKSCrashLib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 39DA35C616184338009EB332 /* libKSCrashLib.a */; };
 		CB78E8B5169C934100C39B02 /* KSObjCApple.h in Headers */ = {isa = PBXBuildFile; fileRef = CB78E8B4169C934100C39B02 /* KSObjCApple.h */; };
 		CB78E8B6169C934100C39B02 /* KSObjCApple.h in Headers */ = {isa = PBXBuildFile; fileRef = CB78E8B4169C934100C39B02 /* KSObjCApple.h */; };
@@ -607,6 +610,7 @@
 		CB5A5B4116C718C400DC1D2D /* KSCrashCallCompletion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSCrashCallCompletion.h; sourceTree = "<group>"; };
 		CB5A5B4216C718C400DC1D2D /* KSCrashCallCompletion.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSCrashCallCompletion.m; sourceTree = "<group>"; };
 		CB5C51771766702000A05F0C /* KSCrashType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KSCrashType.h; sourceTree = "<group>"; };
+		CB5C51871767639400A05F0C /* KSCrashType.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = KSCrashType.c; sourceTree = "<group>"; };
 		CB78E8B4169C934100C39B02 /* KSObjCApple.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSObjCApple.h; sourceTree = "<group>"; };
 		CB78E8B9169C94DA00C39B02 /* KSMachApple.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSMachApple.h; sourceTree = "<group>"; };
 		CB7C753D16CD5DA200227870 /* KSCrashInstallation+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "KSCrashInstallation+Private.h"; sourceTree = "<group>"; };
@@ -912,6 +916,7 @@
 				39DA83A21618450A001E7F79 /* KSCrashReportWriter.h */,
 				39DA83AC1618450A001E7F79 /* KSCrashState.c */,
 				39DA83AD1618450A001E7F79 /* KSCrashState.h */,
+				CB5C51871767639400A05F0C /* KSCrashType.c */,
 				CB5C51771766702000A05F0C /* KSCrashType.h */,
 				39DA83AE1618450A001E7F79 /* KSSystemInfo.h */,
 				39DA83AF1618450A001E7F79 /* KSSystemInfo.m */,
@@ -1474,6 +1479,7 @@
 				CBCED88D175E567F00BF56F0 /* KSCrashSentry_User.c in Sources */,
 				CB05EC6617623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c in Sources */,
 				CB05EC8A176292EA0095353E /* KSCrashSentry_CPPException.cpp in Sources */,
+				CB5C51881767639400A05F0C /* KSCrashType.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1540,6 +1546,7 @@
 				CBCED88F175E567F00BF56F0 /* KSCrashSentry_User.c in Sources */,
 				CB05EC6817623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c in Sources */,
 				CB05EC8C176292EB0095353E /* KSCrashSentry_CPPException.cpp in Sources */,
+				CB5C518A1767639400A05F0C /* KSCrashType.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1636,6 +1643,7 @@
 				CBCED88E175E567F00BF56F0 /* KSCrashSentry_User.c in Sources */,
 				CB05EC6717623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c in Sources */,
 				CB05EC8B176292EB0095353E /* KSCrashSentry_CPPException.cpp in Sources */,
+				CB5C51891767639400A05F0C /* KSCrashType.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/KSCrash/KSCrash.xcodeproj/project.pbxproj
+++ b/KSCrash/KSCrash.xcodeproj/project.pbxproj
@@ -238,6 +238,15 @@
 		39DA84F7161978D7001E7F79 /* NSDictionary+Merge.m in Sources */ = {isa = PBXBuildFile; fileRef = 39DA84F5161978D7001E7F79 /* NSDictionary+Merge.m */; };
 		39DA84F9161978DE001E7F79 /* NSDictionary+Merge.m in Sources */ = {isa = PBXBuildFile; fileRef = 39DA84F5161978D7001E7F79 /* NSDictionary+Merge.m */; };
 		39DA84FD16198753001E7F79 /* NSDictionary+Merge_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 39DA84FB16198753001E7F79 /* NSDictionary+Merge_Tests.m */; };
+		CB05EC6217623AFF0095353E /* KSCrashSentry_CPPException.h in Headers */ = {isa = PBXBuildFile; fileRef = CB05EC6117623AFF0095353E /* KSCrashSentry_CPPException.h */; };
+		CB05EC6317623AFF0095353E /* KSCrashSentry_CPPException.h in Headers */ = {isa = PBXBuildFile; fileRef = CB05EC6117623AFF0095353E /* KSCrashSentry_CPPException.h */; };
+		CB05EC6417623AFF0095353E /* KSCrashSentry_CPPException.h in Headers */ = {isa = PBXBuildFile; fileRef = CB05EC6117623AFF0095353E /* KSCrashSentry_CPPException.h */; };
+		CB05EC6617623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c in Sources */ = {isa = PBXBuildFile; fileRef = CB05EC6517623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c */; };
+		CB05EC6717623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c in Sources */ = {isa = PBXBuildFile; fileRef = CB05EC6517623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c */; };
+		CB05EC6817623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c in Sources */ = {isa = PBXBuildFile; fileRef = CB05EC6517623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c */; };
+		CB05EC8A176292EA0095353E /* KSCrashSentry_CPPException.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CB05EC5D17623AE30095353E /* KSCrashSentry_CPPException.cpp */; };
+		CB05EC8B176292EB0095353E /* KSCrashSentry_CPPException.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CB05EC5D17623AE30095353E /* KSCrashSentry_CPPException.cpp */; };
+		CB05EC8C176292EB0095353E /* KSCrashSentry_CPPException.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CB05EC5D17623AE30095353E /* KSCrashSentry_CPPException.cpp */; };
 		CB0AA0F4167EC43E006EAB99 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = CB0AA0F2167EC43E006EAB99 /* InfoPlist.strings */; };
 		CB0AA0FD167EC460006EAB99 /* KSCrashC.c in Sources */ = {isa = PBXBuildFile; fileRef = 39DA839D1618450A001E7F79 /* KSCrashC.c */; };
 		CB0AA0FE167EC460006EAB99 /* KSCrashC.h in Headers */ = {isa = PBXBuildFile; fileRef = 39DA839E1618450A001E7F79 /* KSCrashC.h */; };
@@ -571,6 +580,9 @@
 		39DA84F4161978D7001E7F79 /* NSDictionary+Merge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.objj.h; path = "NSDictionary+Merge.h"; sourceTree = "<group>"; };
 		39DA84F5161978D7001E7F79 /* NSDictionary+Merge.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+Merge.m"; sourceTree = "<group>"; };
 		39DA84FB16198753001E7F79 /* NSDictionary+Merge_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+Merge_Tests.m"; sourceTree = "<group>"; };
+		CB05EC5D17623AE30095353E /* KSCrashSentry_CPPException.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KSCrashSentry_CPPException.cpp; sourceTree = "<group>"; };
+		CB05EC6117623AFF0095353E /* KSCrashSentry_CPPException.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KSCrashSentry_CPPException.h; sourceTree = "<group>"; };
+		CB05EC6517623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = KSCrashSentry_CPPExceptionDisabled.c; sourceTree = "<group>"; };
 		CB0AA0EE167EC43E006EAB99 /* KSCrashLite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KSCrashLite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB0AA0F1167EC43E006EAB99 /* KSCrashLite-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "KSCrashLite-Info.plist"; sourceTree = "<group>"; };
 		CB0AA0F3167EC43E006EAB99 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -866,6 +878,9 @@
 			children = (
 				39DA83AA1618450A001E7F79 /* KSCrashSentry.c */,
 				39DA83AB1618450A001E7F79 /* KSCrashSentry.h */,
+				CB05EC5D17623AE30095353E /* KSCrashSentry_CPPException.cpp */,
+				CB05EC6117623AFF0095353E /* KSCrashSentry_CPPException.h */,
+				CB05EC6517623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c */,
 				39D329DA16765AD500D989DC /* KSCrashSentry_Deadlock.h */,
 				39D329DB16765AD500D989DC /* KSCrashSentry_Deadlock.m */,
 				39DA83A31618450A001E7F79 /* KSCrashSentry_MachException.c */,
@@ -875,8 +890,8 @@
 				39DA83A71618450A001E7F79 /* KSCrashSentry_Private.h */,
 				39DA83A81618450A001E7F79 /* KSCrashSentry_Signal.c */,
 				39DA83A91618450A001E7F79 /* KSCrashSentry_Signal.h */,
-				CBCED884175E565B00BF56F0 /* KSCrashSentry_User.h */,
 				CBCED88C175E567F00BF56F0 /* KSCrashSentry_User.c */,
+				CBCED884175E565B00BF56F0 /* KSCrashSentry_User.h */,
 			);
 			name = Sentry;
 			sourceTree = "<group>";
@@ -1053,6 +1068,7 @@
 				CBF2D93A16DE86B00003AD7E /* KSCrashInstallationEmail.h in Headers */,
 				CBF2D94016DEDCC10003AD7E /* KSCrashInstallationStandard.h in Headers */,
 				CBCED885175E565B00BF56F0 /* KSCrashSentry_User.h in Headers */,
+				CB05EC6217623AFF0095353E /* KSCrashSentry_CPPException.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1127,6 +1143,7 @@
 				CBF2D93B16DE86B00003AD7E /* KSCrashInstallationEmail.h in Headers */,
 				CBF2D94116DEDCC10003AD7E /* KSCrashInstallationStandard.h in Headers */,
 				CBCED887175E565B00BF56F0 /* KSCrashSentry_User.h in Headers */,
+				CB05EC6417623AFF0095353E /* KSCrashSentry_CPPException.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1190,6 +1207,7 @@
 				CB1B377016D74F3C00FFFCEA /* KSCString.h in Headers */,
 				CB1B378716D820AE00FFFCEA /* KSSingleton.h in Headers */,
 				CBCED886175E565B00BF56F0 /* KSCrashSentry_User.h in Headers */,
+				CB05EC6317623AFF0095353E /* KSCrashSentry_CPPException.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1446,6 +1464,8 @@
 				2122BBD116F185120056D11C /* KSCrashReportSinkTakanashi.m in Sources */,
 				2193ACC616F19D690016EA5F /* KSCrashInstallationTakanashi.m in Sources */,
 				CBCED88D175E567F00BF56F0 /* KSCrashSentry_User.c in Sources */,
+				CB05EC6617623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c in Sources */,
+				CB05EC8A176292EA0095353E /* KSCrashSentry_CPPException.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1510,6 +1530,8 @@
 				2122BBD216F185120056D11C /* KSCrashReportSinkTakanashi.m in Sources */,
 				2193ACC716F19D690016EA5F /* KSCrashInstallationTakanashi.m in Sources */,
 				CBCED88F175E567F00BF56F0 /* KSCrashSentry_User.c in Sources */,
+				CB05EC6817623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c in Sources */,
+				CB05EC8C176292EB0095353E /* KSCrashSentry_CPPException.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1604,6 +1626,8 @@
 				CB7C754716CD5F5F00227870 /* KSCrashInstallation.m in Sources */,
 				CB1B377316D74F3C00FFFCEA /* KSCString.m in Sources */,
 				CBCED88E175E567F00BF56F0 /* KSCrashSentry_User.c in Sources */,
+				CB05EC6717623C000095353E /* KSCrashSentry_CPPExceptionDisabled.c in Sources */,
+				CB05EC8B176292EB0095353E /* KSCrashSentry_CPPException.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1696,7 +1720,7 @@
 				GCC_WARN_UNUSED_LABEL = YES;
 				GCC_WARN_UNUSED_PARAMETER = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				SDKROOT = iphoneos;
 				STRIP_STYLE = debugging;
 			};
@@ -1741,7 +1765,7 @@
 				GCC_WARN_UNUSED_LABEL = YES;
 				GCC_WARN_UNUSED_PARAMETER = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				SDKROOT = iphoneos;
 				STRIP_STYLE = debugging;
 				VALIDATE_PRODUCT = YES;

--- a/KSCrash/KSCrash/KSCrash.h
+++ b/KSCrash/KSCrash/KSCrash.h
@@ -29,6 +29,7 @@
 
 #import "KSCrashReportWriter.h"
 #import "KSCrashReportFilter.h"
+#import "KSCrashType.h"
 
 
 typedef enum
@@ -69,6 +70,12 @@ typedef enum
  * Default: KSCDeleteAlways
  */
 @property(nonatomic,readwrite,assign) KSCDeleteBehavior deleteBehaviorAfterSendAll;
+
+/** The crash types that are being handled.
+ * Note: This value may change once KSCrash is installed if some handlers
+ *       fail to install.
+ */
+@property(nonatomic,readwrite,assign) KSCrashType handlingCrashTypes;
 
 /** The size of the cache to use for on-device zombie tracking.
  * Every deallocated object will be hashed based on its address modulus the cache

--- a/KSCrash/KSCrash/KSCrash.h
+++ b/KSCrash/KSCrash/KSCrash.h
@@ -46,12 +46,6 @@ typedef enum
  */
 @interface KSCrash : NSObject
 
-/** The report sink where reports get sent.
- * This MUST be set or else the reporter will not send reports (although it will
- * still record them).
- */
-@property(nonatomic,readwrite,retain) id<KSCrashReportFilter> sink;
-
 /** A dictionary containing any info you'd like to appear in crash reports. Must
  * contain only JSON-safe data: NSString for keys, and NSDictionary, NSArray,
  * NSString, NSDate, and NSNumber for values.
@@ -127,20 +121,6 @@ typedef enum
  * Default: nil
  */
 @property(nonatomic,readwrite,retain) NSArray* doNotIntrospectClasses;
-
-/** If YES, print a stack trace to stdout when a crash occurs.
- *
- * Default: NO
- */
-@property(nonatomic,readwrite,assign) bool printTraceToStdout;
-
-/** C Function to call during a crash report to give the callee an opportunity to
- * add to the report. NULL = ignore.
- *
- * WARNING: Only call async-safe functions from this function! DO NOT call
- * Objective-C methods!!!
- */
-@property(nonatomic,readwrite,assign) KSReportWriteCallback onCrash;
 
 
 /** Get the singleton instance of the crash reporter.

--- a/KSCrash/KSCrash/KSCrash.m
+++ b/KSCrash/KSCrash/KSCrash.m
@@ -70,18 +70,18 @@
 
 @interface KSCrash ()
 
-@property(nonatomic, readwrite, retain) NSString* bundleName;
-@property(nonatomic, readwrite, retain) NSString* nextCrashID;
-@property(nonatomic, readonly, retain) NSString* crashReportPath;
-@property(nonatomic, readonly, retain) NSString* recrashReportPath;
-@property(nonatomic, readonly, retain) NSString* stateFilePath;
+@property(nonatomic,readwrite,retain) NSString* bundleName;
+@property(nonatomic,readwrite,retain) NSString* nextCrashID;
+@property(nonatomic,readonly,retain) NSString* crashReportPath;
+@property(nonatomic,readonly,retain) NSString* recrashReportPath;
+@property(nonatomic,readonly,retain) NSString* stateFilePath;
 
-@end
-
-@interface KSCrash (Private)
-
-@property(nonatomic, readwrite, retain) NSString* logFilePath;
-@property(nonatomic, readwrite, retain) KSCrashReportStore* crashReportStore;
+// Mirrored from KSCrashAdvanced.h to provide ivars
+@property(nonatomic,readwrite,retain) id<KSCrashReportFilter> sink;
+@property(nonatomic,readwrite,retain) NSString* logFilePath;
+@property(nonatomic,readwrite,retain) KSCrashReportStore* crashReportStore;
+@property(nonatomic,readwrite,assign) KSReportWriteCallback onCrash;
+@property(nonatomic,readwrite,assign) bool printTraceToStdout;
 
 @end
 

--- a/KSCrash/KSCrash/KSCrash.m
+++ b/KSCrash/KSCrash/KSCrash.m
@@ -90,6 +90,7 @@
 @synthesize sink = _sink;
 @synthesize userInfo = _userInfo;
 @synthesize deleteBehaviorAfterSendAll = _deleteBehaviorAfterSendAll;
+@synthesize handlingCrashTypes = _handlingCrashTypes;
 @synthesize zombieCacheSize = _zombieCacheSize;
 @synthesize deadlockWatchdogInterval = _deadlockWatchdogInterval;
 @synthesize printTraceToStdout = _printTraceToStdout;
@@ -190,6 +191,11 @@ failed:
     kscrash_setUserInfoJSON([userInfoJSON bytes]);
 }
 
+- (void) setHandlingCrashTypes:(KSCrashType)handlingCrashTypes
+{
+    _handlingCrashTypes = kscrash_setHandlingCrashTypes(handlingCrashTypes);
+}
+
 - (void) setZombieCacheSize:(size_t) zombieCacheSize
 {
     _zombieCacheSize = zombieCacheSize;
@@ -259,10 +265,11 @@ failed:
 
 - (BOOL) install
 {
-    if(!kscrash_install([self.crashReportPath UTF8String],
-                        [self.recrashReportPath UTF8String],
-                        [self.stateFilePath UTF8String],
-                        [self.nextCrashID UTF8String]))
+    _handlingCrashTypes = kscrash_install([self.crashReportPath UTF8String],
+                                          [self.recrashReportPath UTF8String],
+                                          [self.stateFilePath UTF8String],
+                                          [self.nextCrashID UTF8String]);
+    if(self.handlingCrashTypes == 0)
     {
         return false;
     }

--- a/KSCrash/KSCrash/KSCrash.m
+++ b/KSCrash/KSCrash/KSCrash.m
@@ -375,6 +375,21 @@ failed:
 #pragma mark - Advanced API -
 // ============================================================================
 
+#define SYNTHESIZE_CRASH_STATE_PROPERTY(TYPE, NAME) \
+- (TYPE) NAME \
+{ \
+    return kscrashstate_currentState()->NAME; \
+}
+
+SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, activeDurationSinceLastCrash)
+SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, backgroundDurationSinceLastCrash)
+SYNTHESIZE_CRASH_STATE_PROPERTY(int, launchesSinceLastCrash)
+SYNTHESIZE_CRASH_STATE_PROPERTY(int, sessionsSinceLastCrash)
+SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, activeDurationSinceLaunch)
+SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, backgroundDurationSinceLaunch)
+SYNTHESIZE_CRASH_STATE_PROPERTY(int, sessionsSinceLaunch)
+SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
+
 - (NSUInteger) reportCount
 {
     return [self.crashReportStore reportCount];

--- a/KSCrash/KSCrash/KSCrash.m
+++ b/KSCrash/KSCrash/KSCrash.m
@@ -71,12 +71,17 @@
 @interface KSCrash ()
 
 @property(nonatomic, readwrite, retain) NSString* bundleName;
-@property(nonatomic, readwrite, retain) NSString* logFilePath;
 @property(nonatomic, readwrite, retain) NSString* nextCrashID;
-@property(nonatomic, readwrite, retain) KSCrashReportStore* crashReportStore;
 @property(nonatomic, readonly, retain) NSString* crashReportPath;
 @property(nonatomic, readonly, retain) NSString* recrashReportPath;
 @property(nonatomic, readonly, retain) NSString* stateFilePath;
+
+@end
+
+@interface KSCrash (Private)
+
+@property(nonatomic, readwrite, retain) NSString* logFilePath;
+@property(nonatomic, readwrite, retain) KSCrashReportStore* crashReportStore;
 
 @end
 

--- a/KSCrash/KSCrash/KSCrashAdvanced.h
+++ b/KSCrash/KSCrash/KSCrashAdvanced.h
@@ -32,10 +32,30 @@
 /**
  * Advanced interface to the KSCrash system.
  */
-@interface KSCrash (Advanced)
+@interface KSCrash ()
 
 /** Store containing all crash reports. */
 @property(nonatomic, readwrite, retain) KSCrashReportStore* crashReportStore;
+
+/** The report sink where reports get sent.
+ * This MUST be set or else the reporter will not send reports (although it will
+ * still record them).
+ *
+ * Note: If you use an installation, it will automatically set this property.
+ *       Do not modify it in such a case.
+ */
+@property(nonatomic,readwrite,retain) id<KSCrashReportFilter> sink;
+
+/** C Function to call during a crash report to give the callee an opportunity to
+ * add to the report. NULL = ignore.
+ *
+ * WARNING: Only call async-safe functions from this function! DO NOT call
+ * Objective-C methods!!!
+ *
+ * Note: If you use an installation, it will automatically set this property.
+ *       Do not modify it in such a case.
+ */
+@property(nonatomic,readwrite,assign) KSReportWriteCallback onCrash;
 
 /** Path where the log of KSCrash's activities will be written.
  * If nil, log entries will be printed to the console.
@@ -46,6 +66,12 @@
  * Default: nil
  */
 @property(nonatomic, readonly, retain) NSString* logFilePath;
+
+/** If YES, print a stack trace to stdout when a crash occurs.
+ *
+ * Default: NO
+ */
+@property(nonatomic,readwrite,assign) bool printTraceToStdout;
 
 /** Send the specified reports to the current sink.
  *

--- a/KSCrash/KSCrash/KSCrashAdvanced.h
+++ b/KSCrash/KSCrash/KSCrashAdvanced.h
@@ -32,7 +32,7 @@
 /**
  * Advanced interface to the KSCrash system.
  */
-@interface KSCrash ()
+@interface KSCrash (Advanced)
 
 #pragma mark - Information -
 
@@ -102,7 +102,7 @@
  *
  * Default: nil
  */
-@property(nonatomic, readonly, retain) NSString* logFilePath;
+@property(nonatomic,readonly,retain) NSString* logFilePath;
 
 /** If YES, print a stack trace to stdout when a crash occurs.
  *

--- a/KSCrash/KSCrash/KSCrashAdvanced.h
+++ b/KSCrash/KSCrash/KSCrashAdvanced.h
@@ -34,6 +34,43 @@
  */
 @interface KSCrash ()
 
+#pragma mark - Information -
+
+/** Total active time elapsed since the last crash. */
+@property(nonatomic,readonly,assign) NSTimeInterval activeDurationSinceLastCrash;
+
+/** Total time backgrounded elapsed since the last crash. */
+@property(nonatomic,readonly,assign) NSTimeInterval backgroundDurationSinceLastCrash;
+
+/** Number of app launches since the last crash. */
+@property(nonatomic,readonly,assign) int launchesSinceLastCrash;
+
+/** Number of sessions (launch, resume from suspend) since last crash. */
+@property(nonatomic,readonly,assign) int sessionsSinceLastCrash;
+
+/** Total active time elapsed since launch. */
+@property(nonatomic,readonly,assign) NSTimeInterval activeDurationSinceLaunch;
+
+/** Total time backgrounded elapsed since launch. */
+@property(nonatomic,readonly,assign) NSTimeInterval backgroundDurationSinceLaunch;
+
+/** Number of sessions (launch, resume from suspend) since app launch. */
+@property(nonatomic,readonly,assign) int sessionsSinceLaunch;
+
+/** If true, the application crashed on the previous launch. */
+@property(nonatomic,readonly,assign) BOOL crashedLastLaunch;
+
+/** The total number of unsent reports. Note: This is an expensive operation.
+ */
+- (NSUInteger) reportCount;
+
+/** Get all reports, with data types corrected, as dictionaries.
+ */
+- (NSArray*) allReports;
+
+
+#pragma mark - Configuration -
+
 /** Store containing all crash reports. */
 @property(nonatomic, readwrite, retain) KSCrashReportStore* crashReportStore;
 
@@ -73,21 +110,6 @@
  */
 @property(nonatomic,readwrite,assign) bool printTraceToStdout;
 
-/** Send the specified reports to the current sink.
- *
- * @param reports The reports to send.
- * @param onCompletion Called when sending is complete (nil = ignore).
- */
-- (void) sendReports:(NSArray*) reports onCompletion:(KSCrashReportFilterCompletion) onCompletion;
-
-/** The total number of unsent reports. Note: This is an expensive operation.
- */
-- (NSUInteger) reportCount;
-
-/** Get all reports, with data types corrected, as dictionaries.
- */
-- (NSArray*) allReports;
-
 /** Sets logFilePath to the default log file location
  * (Library/Caches/KSCrashReports/<bundle name>-CrashLog.txt).
  * If the file exists, it will be overwritten.
@@ -105,5 +127,14 @@
  */
 - (BOOL) redirectConsoleLogsToFile:(NSString*) fullPath overwrite:(BOOL) overwrite;
 
-@end
 
+#pragma mark - Operations -
+
+/** Send the specified reports to the current sink.
+ *
+ * @param reports The reports to send.
+ * @param onCompletion Called when sending is complete (nil = ignore).
+ */
+- (void) sendReports:(NSArray*) reports onCompletion:(KSCrashReportFilterCompletion) onCompletion;
+
+@end

--- a/KSCrash/KSCrash/KSCrashC.c
+++ b/KSCrash/KSCrash/KSCrashC.c
@@ -182,8 +182,17 @@ KSCrashType kscrash_setHandlingCrashTypes(KSCrashType crashTypes)
 {
     if((crashTypes & KSCrashTypeDebuggerUnsafe) && ksmach_isBeingTraced())
     {
-        KSLOGBASIC_WARN("KSCrash: App is running in a debugger. Crash types 0x%02x have been disabled.",
-                        (crashTypes & KSCrashTypeDebuggerUnsafe));
+        KSLOGBASIC_WARN("KSCrash: App is running in a debugger. The following crash types have been disabled:");
+        KSCrashType disabledCrashTypes = crashTypes & KSCrashTypeDebuggerUnsafe;
+        for(int i = 0; i < 31; i++)
+        {
+            KSCrashType type = 1 << i;
+            if(disabledCrashTypes & type)
+            {
+                KSLOGBASIC_WARN("* %s", kscrashtype_name(type));
+            }
+        }
+
         crashTypes &= KSCrashTypeDebuggerSafe;
     }
 

--- a/KSCrash/KSCrash/KSCrashC.h
+++ b/KSCrash/KSCrash/KSCrashC.h
@@ -54,12 +54,25 @@ extern "C" {
  *
  * @param crashID The unique identifier to assign to the next crash report.
  *
- * @return true if installation was successful.
+ * @return The crash types that are being handled.
  */
-bool kscrash_install(const char* const crashReportFilePath,
-                     const char* const recrashReportFilePath,
-                     const char* stateFilePath,
-                     const char* crashID);
+KSCrashType kscrash_install(const char* const crashReportFilePath,
+                            const char* const recrashReportFilePath,
+                            const char* stateFilePath,
+                            const char* crashID);
+
+/** Set the crash types that will be handled.
+ * Some crash types may not be enabled depending on circumstances (e.g. running
+ * in a debugger).
+ *
+ * @param crashTypes The crash types to handle.
+ *
+ * @return The crash types that are now behing handled. If KSCrash has been
+ *         installed, the return value represents the crash sentries that were
+ *         successfully installed. Otherwise it represents which sentries it
+ *         will attempt to activate when KSCrash installs.
+ */
+KSCrashType kscrash_setHandlingCrashTypes(KSCrashType crashTypes);
 
 /** Reinstall the crash reporter. Useful for resetting the crash reporter
  * after a "soft" crash.

--- a/KSCrash/KSCrash/KSCrashContext.h
+++ b/KSCrash/KSCrash/KSCrashContext.h
@@ -76,7 +76,10 @@ typedef struct
 
     /** When writing the crash report, print a stack trace to STDOUT as well. */
     bool printTraceToStdout;
-    
+
+    /** The types of crashes that will be handled. */
+    KSCrashType handlingCrashTypes;
+
     /** Rules for introspecting Objective-C objects. */
     KSCrash_IntrospectionRules introspectionRules;
     

--- a/KSCrash/KSCrash/KSCrashInstallation.m
+++ b/KSCrash/KSCrash/KSCrashInstallation.m
@@ -28,7 +28,7 @@
 #import "KSCrashInstallation.h"
 #import "KSCrashInstallation+Private.h"
 #import "ARCSafe_MemMgmt.h"
-#import "KSCrash.h"
+#import "KSCrashAdvanced.h"
 #import "KSCrashReportFilterAlert.h"
 #import "KSCString.h"
 #import "KSJSONCodecObjC.h"

--- a/KSCrash/KSCrash/KSCrashReport.c
+++ b/KSCrash/KSCrash/KSCrashReport.c
@@ -1036,7 +1036,7 @@ void kscrw_i_writeAddressReferencedByString(const KSCrashReportWriter* const wri
                                             const char* string)
 {
     uint64_t address = 0;
-    if(!ksstring_extractHexValue(string, strlen(string), &address))
+    if(string == NULL || !ksstring_extractHexValue(string, strlen(string), &address))
     {
         return;
     }

--- a/KSCrash/KSCrash/KSCrashReportFields.h
+++ b/KSCrash/KSCrash/KSCrashReportFields.h
@@ -47,6 +47,7 @@
 
 #pragma mark - Exception Types -
 
+#define KSCrashExcType_CPPException        "cpp_exception"
 #define KSCrashExcType_Deadlock            "deadlock"
 #define KSCrashExcType_Mach                "mach"
 #define KSCrashExcType_NSException         "nsexception"

--- a/KSCrash/KSCrash/KSCrashReportFields.h
+++ b/KSCrash/KSCrash/KSCrashReportFields.h
@@ -130,6 +130,7 @@
 #define KSCrashField_Backtrace             "backtrace"
 #define KSCrashField_Code                  "code"
 #define KSCrashField_CodeName              "code_name"
+#define KSCrashField_CPPException          "cpp_exception"
 #define KSCrashField_ExceptionName         "exception_name"
 #define KSCrashField_Mach                  "mach"
 #define KSCrashField_NSException           "nsexception"

--- a/KSCrash/KSCrash/KSCrashReportFilterAppleFmt.m
+++ b/KSCrash/KSCrash/KSCrashReportFilterAppleFmt.m
@@ -630,6 +630,7 @@ NSDictionary* g_registerOrders;
     NSDictionary* type = [error objectForKey:@KSCrashField_Type];
 
     NSDictionary* nsexception = [error objectForKey:@KSCrashField_NSException];
+    NSDictionary* cppexception = [error objectForKey:@KSCrashField_CPPException];
     NSDictionary* lastException = [[self processReport:report] objectForKey:@KSCrashField_LastDeallocedNSException];
     NSDictionary* userException = [error objectForKey:@KSCrashField_UserReported];
     NSDictionary* mach = [error objectForKey:@KSCrashField_Mach];
@@ -683,8 +684,8 @@ NSDictionary* g_registerOrders;
     }
     else if([type isEqual:@KSCrashExcType_CPPException])
     {
-        [str appendString:[self stringWithUncaughtExceptionName:@"C++"
-                                                         reason:@"Uncaught C++ Exception"]];
+        [str appendString:[self stringWithUncaughtExceptionName:[cppexception objectForKey:@KSCrashField_Name]
+                                                         reason:[error objectForKey:@KSCrashField_Reason]]];
     }
 
     if([@KSCrashExcType_Deadlock isEqualToString:[error objectForKey:@KSCrashField_Type]])

--- a/KSCrash/KSCrash/KSCrashReportFilterAppleFmt.m
+++ b/KSCrash/KSCrash/KSCrashReportFilterAppleFmt.m
@@ -627,6 +627,7 @@ NSDictionary* g_registerOrders;
     NSDictionary* thread = [self crashedThread:report];
     NSDictionary* crash = [self crashReport:report];
     NSDictionary* error = [crash objectForKey:@KSCrashField_Error];
+    NSDictionary* type = [error objectForKey:@KSCrashField_Type];
 
     NSDictionary* nsexception = [error objectForKey:@KSCrashField_NSException];
     NSDictionary* lastException = [[self processReport:report] objectForKey:@KSCrashField_LastDeallocedNSException];
@@ -679,6 +680,11 @@ NSDictionary* g_registerOrders;
         {
             [str appendFormat:@"\n%@\n", trace];
         }
+    }
+    else if([type isEqual:@KSCrashExcType_CPPException])
+    {
+        [str appendString:[self stringWithUncaughtExceptionName:@"C++"
+                                                         reason:@"Uncaught C++ Exception"]];
     }
 
     if([@KSCrashExcType_Deadlock isEqualToString:[error objectForKey:@KSCrashField_Type]])

--- a/KSCrash/KSCrash/KSCrashReportFilterAppleFmt.m
+++ b/KSCrash/KSCrash/KSCrashReportFilterAppleFmt.m
@@ -511,6 +511,7 @@ NSDictionary* g_registerOrders;
 
     [str appendString:@"\nExtra Information:\n"];
 
+    NSDictionary* system = [self systemReport:report];
     NSDictionary* crash = [self crashReport:report];
     NSDictionary* error = [crash objectForKey:@KSCrashField_Error];
     NSDictionary* nsexception = [error objectForKey:@KSCrashField_NSException];
@@ -556,6 +557,12 @@ NSDictionary* g_registerOrders;
          [self backtraceString:[lastException objectForKey:@KSCrashField_Backtrace]
                    reportStyle:self.reportStyle
             mainExecutableName:mainExecutableName]];
+    }
+
+    NSDictionary* appStats = [system objectForKey:@KSCrashField_AppStats];
+    if(appStats != nil)
+    {
+        [str appendFormat:@"\nApplication Stats:\n%@\n", [self JSONForObject:appStats]];
     }
 
     NSDictionary* crashReport = [report objectForKey:@KSCrashField_Crash];

--- a/KSCrash/KSCrash/KSCrashSentry.c
+++ b/KSCrash/KSCrash/KSCrashSentry.c
@@ -30,6 +30,7 @@
 
 #include "KSCrashSentry_Deadlock.h"
 #include "KSCrashSentry_MachException.h"
+#include "KSCrashSentry_CPPException.h"
 #include "KSCrashSentry_NSException.h"
 #include "KSCrashSentry_Signal.h"
 #include "KSCrashSentry_User.h"
@@ -61,6 +62,11 @@ static CrashSentry g_sentries[] =
         KSCrashTypeSignal,
         kscrashsentry_installSignalHandler,
         kscrashsentry_uninstallSignalHandler,
+    },
+    {
+        KSCrashTypeCPPException,
+        kscrashsentry_installCPPExceptionHandler,
+        kscrashsentry_uninstallCPPExceptionHandler,
     },
     {
         KSCrashTypeNSException,

--- a/KSCrash/KSCrash/KSCrashSentry.h
+++ b/KSCrash/KSCrash/KSCrashSentry.h
@@ -37,31 +37,12 @@ extern "C" {
 #endif
 
 
+#include "KSCrashType.h"
+
 #include <mach/mach_types.h>
 #include <signal.h>
 #include <stdbool.h>
 
-
-/** Different ways an application can crash:
- * - Mach kernel exception
- * - Fatal signal
- * - Uncaught C++ exception
- * - Uncaught Objective-C NSException
- * - Deadlock on the main thread
- * - User reported custom exception
- */
-typedef enum
-{
-    KSCrashTypeMachException      = 0x01,
-    KSCrashTypeSignal             = 0x02,
-    KSCrashTypeCPPException       = 0x04,
-    KSCrashTypeNSException        = 0x08,
-    KSCrashTypeMainThreadDeadlock = 0x10,
-    KSCrashTypeUserReported       = 0x20,
-} KSCrashType;
-
-#define KSCrashTypeAll (KSCrashTypeMachException | KSCrashTypeSignal | KSCrashTypeCPPException |KSCrashTypeNSException | KSCrashTypeMainThreadDeadlock | KSCrashTypeUserReported)
-#define KSCrashTypeAsyncSafe (KSCrashTypeMachException | KSCrashTypeSignal)
 
 typedef enum
 {

--- a/KSCrash/KSCrash/KSCrashSentry.h
+++ b/KSCrash/KSCrash/KSCrashSentry.h
@@ -45,6 +45,7 @@ extern "C" {
 /** Different ways an application can crash:
  * - Mach kernel exception
  * - Fatal signal
+ * - Uncaught C++ exception
  * - Uncaught Objective-C NSException
  * - Deadlock on the main thread
  * - User reported custom exception
@@ -53,12 +54,13 @@ typedef enum
 {
     KSCrashTypeMachException      = 0x01,
     KSCrashTypeSignal             = 0x02,
-    KSCrashTypeNSException        = 0x04,
-    KSCrashTypeMainThreadDeadlock = 0x08,
-    KSCrashTypeUserReported       = 0x10,
+    KSCrashTypeCPPException       = 0x04,
+    KSCrashTypeNSException        = 0x08,
+    KSCrashTypeMainThreadDeadlock = 0x10,
+    KSCrashTypeUserReported       = 0x20,
 } KSCrashType;
 
-#define KSCrashTypeAll (KSCrashTypeMachException | KSCrashTypeSignal | KSCrashTypeNSException | KSCrashTypeMainThreadDeadlock | KSCrashTypeUserReported)
+#define KSCrashTypeAll (KSCrashTypeMachException | KSCrashTypeSignal | KSCrashTypeCPPException |KSCrashTypeNSException | KSCrashTypeMainThreadDeadlock | KSCrashTypeUserReported)
 #define KSCrashTypeAsyncSafe (KSCrashTypeMachException | KSCrashTypeSignal)
 
 typedef enum

--- a/KSCrash/KSCrash/KSCrashSentry.h
+++ b/KSCrash/KSCrash/KSCrashSentry.h
@@ -137,6 +137,13 @@ typedef struct KSCrash_SentryContext
 
     struct
     {
+        /** The exception name. */
+        const char* name;
+
+    } CPPException;
+    
+    struct
+    {
         /** User context information. */
         const ucontext_t* userContext;
 

--- a/KSCrash/KSCrash/KSCrashSentry_CPPException.cpp
+++ b/KSCrash/KSCrash/KSCrashSentry_CPPException.cpp
@@ -1,0 +1,159 @@
+//
+//  KSCrashSentry_CPPException.c
+//
+//  Copyright (c) 2012 Karl Stenerud. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "KSCrashSentry_CPPException.h"
+#include "KSCrashSentry_Private.h"
+
+//#define KSLogger_LocalLevel TRACE
+#include "KSLogger.h"
+
+#include <dlfcn.h>
+#include <execinfo.h>
+#include <exception>
+#include <mach/mach.h>
+#include <stdlib.h>
+#include <typeinfo>
+
+
+#define STACKTRACE_BUFFER_LENGTH 30
+
+
+// Compiler hints for "if" statements
+#define likely_if(x) if(__builtin_expect(x,1))
+#define unlikely_if(x) if(__builtin_expect(x,0))
+
+
+// ============================================================================
+#pragma mark - Globals -
+// ============================================================================
+
+/** True if this handler has been installed.
+ * Note: We are not using sig_atomic or volatile since c++ exceptions can happen
+ * quite frequently.
+ */
+static bool g_installed = false;
+
+/** Buffer for the backtrace of the most recent exception. */
+static uintptr_t g_stackTrace[STACKTRACE_BUFFER_LENGTH];
+
+/** Number of backtrace entries in the most recent exception. */
+static int g_stackTraceCount = 0;
+
+/** Context to fill with crash information. */
+static KSCrash_SentryContext* g_context;
+
+
+// ============================================================================
+#pragma mark - Callbacks -
+// ============================================================================
+
+typedef void (*cxa_throw_type)(void*, void*, void (*)(void*));
+
+extern "C" void __cxa_throw(void* thrown_exception, void* tinfo, void (*dest)(void*))
+{
+    if(g_installed)
+    {
+        g_stackTraceCount = backtrace((void**)g_stackTrace, sizeof(g_stackTrace) / sizeof(*g_stackTrace));
+    }
+
+    static cxa_throw_type orig_cxa_throw = NULL;
+    unlikely_if(orig_cxa_throw == NULL)
+    {
+        orig_cxa_throw = (cxa_throw_type) dlsym(RTLD_NEXT, "__cxa_throw");
+    }
+    orig_cxa_throw(thrown_exception, tinfo, dest);
+}
+
+
+static void CPPExceptionTerminate_Installed(void)
+{
+    KSLOG_DEBUG("Trapped c++ exception %s", g_exception_cause);
+    bool wasHandlingCrash = g_context->handlingCrash;
+    kscrashsentry_beginHandlingCrash(g_context);
+
+    KSLOG_DEBUG("Exception handler is installed. Continuing exception handling.");
+
+    if(wasHandlingCrash)
+    {
+        KSLOG_INFO("Detected crash in the crash reporter. Restoring original handlers.");
+        g_context->crashedDuringCrashHandling = true;
+        kscrashsentry_uninstall((KSCrashType)KSCrashTypeAll);
+    }
+
+    KSLOG_DEBUG(@"Suspending all threads.");
+    kscrashsentry_suspendThreads();
+
+    g_context->crashType = KSCrashTypeCPPException;
+    g_context->offendingThread = mach_thread_self();
+    g_context->registersAreValid = false;
+    g_context->stackTrace = g_stackTrace + 1; // Don't record __cxa_throw
+    g_context->stackTraceLength = g_stackTraceCount - 1;
+
+    KSLOG_DEBUG(@"Calling main crash handler.");
+    g_context->onCrash();
+
+    KSLOG_DEBUG(@"Crash handling complete. Restoring original handlers.");
+    kscrashsentry_uninstall((KSCrashType)KSCrashTypeAll);
+    abort();
+}
+
+static void CPPExceptionTerminate_Uninstalled(void)
+{
+    abort();
+}
+
+
+// ============================================================================
+#pragma mark - Public API -
+// ============================================================================
+
+extern "C" bool kscrashsentry_installCPPExceptionHandler(KSCrash_SentryContext* context)
+{
+    KSLOG_DEBUG("Installing C++ exception handler.");
+
+    if(g_installed)
+    {
+        KSLOG_DEBUG("C++ exception handler already installed.");
+        return true;
+    }
+    g_installed = true;
+
+    g_context = context;
+
+    std::set_terminate(CPPExceptionTerminate_Installed);
+    return true;
+}
+
+extern "C" void kscrashsentry_uninstallCPPExceptionHandler(void)
+{
+    KSLOG_DEBUG("Uninstalling C++ exception handlers.");
+    if(!g_installed)
+    {
+        KSLOG_DEBUG("C++ exception handlers were already uninstalled.");
+        return;
+    }
+
+    std::set_terminate(CPPExceptionTerminate_Uninstalled);
+    g_installed = false;
+}

--- a/KSCrash/KSCrash/KSCrashSentry_CPPException.cpp
+++ b/KSCrash/KSCrash/KSCrashSentry_CPPException.cpp
@@ -135,66 +135,26 @@ static void CPPExceptionTerminate(void)
             {
                 description = exc.what();
             }
-            catch(char value)
-            {
-                snprintf(descriptionBuff, sizeof(descriptionBuff), "%d", value);
-            }
-            catch(unsigned char value)
-            {
-                snprintf(descriptionBuff, sizeof(descriptionBuff), "%u", value);
-            }
-            catch(short value)
-            {
-                snprintf(descriptionBuff, sizeof(descriptionBuff), "%d", value);
-            }
-            catch(unsigned short value)
-            {
-                snprintf(descriptionBuff, sizeof(descriptionBuff), "%u", value);
-            }
-            catch(int value)
-            {
-                snprintf(descriptionBuff, sizeof(descriptionBuff), "%d", value);
-            }
-            catch(unsigned int value)
-            {
-                snprintf(descriptionBuff, sizeof(descriptionBuff), "%u", value);
-            }
-            catch(long value)
-            {
-                snprintf(descriptionBuff, sizeof(descriptionBuff), "%ld", value);
-            }
-            catch(unsigned long value)
-            {
-                snprintf(descriptionBuff, sizeof(descriptionBuff), "%lu", value);
-            }
-            catch(long long value)
-            {
-                snprintf(descriptionBuff, sizeof(descriptionBuff), "%lld", value);
-            }
-            catch(unsigned long long value)
-            {
-                snprintf(descriptionBuff, sizeof(descriptionBuff), "%llu", value);
-            }
-            catch(float value)
-            {
-                snprintf(descriptionBuff, sizeof(descriptionBuff), "%f", value);
-            }
-            catch(double value)
-            {
-                snprintf(descriptionBuff, sizeof(descriptionBuff), "%f", value);
-            }
-            catch(long double value)
-            {
-                snprintf(descriptionBuff, sizeof(descriptionBuff), "%Lf", value);
-            }
-            catch(char* value)
-            {
-                snprintf(descriptionBuff, sizeof(descriptionBuff), "%s", value);
-            }
-            catch(const char* value)
-            {
-                snprintf(descriptionBuff, sizeof(descriptionBuff), "%s", value);
-            }
+#define CATCH_VALUE(TYPE, PRINTFTYPE) \
+catch(TYPE value)\
+{ \
+    snprintf(descriptionBuff, sizeof(descriptionBuff), "%" #PRINTFTYPE, value); \
+}
+            CATCH_VALUE(char,                 d)
+            CATCH_VALUE(short,                d)
+            CATCH_VALUE(int,                  d)
+            CATCH_VALUE(long,                ld)
+            CATCH_VALUE(long long,          lld)
+            CATCH_VALUE(unsigned char,        u)
+            CATCH_VALUE(unsigned short,       u)
+            CATCH_VALUE(unsigned int,         u)
+            CATCH_VALUE(unsigned long,       lu)
+            CATCH_VALUE(unsigned long long, llu)
+            CATCH_VALUE(float,                f)
+            CATCH_VALUE(double,               f)
+            CATCH_VALUE(long double,         Lf)
+            CATCH_VALUE(char*,                s)
+            CATCH_VALUE(const char*,          s)
             catch(...)
             {
                 description = NULL;

--- a/KSCrash/KSCrash/KSCrashSentry_CPPException.h
+++ b/KSCrash/KSCrash/KSCrashSentry_CPPException.h
@@ -1,7 +1,5 @@
 //
-//  KSCrashSentry_Private.h
-//
-//  Created by Karl Stenerud on 2012-09-29.
+//  KSCrashSentry_CPPException.h
 //
 //  Copyright (c) 2012 Karl Stenerud. All rights reserved.
 //
@@ -24,43 +22,32 @@
 // THE SOFTWARE.
 //
 
-
-#ifndef HDR_KSCrashSentry_Private_h
-#define HDR_KSCrashSentry_Private_h
+#ifndef HDR_KSCrashSentry_CPPException_h
+#define HDR_KSCrashSentry_CPPException_h
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-    
+
 #include "KSCrashSentry.h"
 
 
-/** Suspend all non-reserved threads.
+/** Install the C++ exception handler.
  *
- * Reserved threads include the current thread and all threads in
- "reservedThreads" in the context.
- */
-void kscrashsentry_suspendThreads(void);
-
-/** Resume all non-reserved threads.
+ * @param context Contextual information for the crash handler.
  *
- * Reserved threads include the current thread and all threads in
- * "reservedThreads" in the context.
+ * @return true if installation was succesful.
  */
-void kscrashsentry_resumeThreads(void);
+bool kscrashsentry_installCPPExceptionHandler(KSCrash_SentryContext* context);
 
-/** Prepare the context for handling a new crash.
+/** Uninstall the C++ exception handler.
  */
-void kscrashsentry_beginHandlingCrash(KSCrash_SentryContext* context);
+void kscrashsentry_uninstallCPPExceptionHandler(void);
 
-/** Clear a crash sentry context.
- */
-void kscrashsentry_clearContext(KSCrash_SentryContext* context);
 
-    
 #ifdef __cplusplus
 }
 #endif
 
-#endif // HDR_KSCrashSentry_Private_h
+#endif // HDR_KSCrashSentry_CPPException_h

--- a/KSCrash/KSCrash/KSCrashSentry_CPPExceptionDisabled.c
+++ b/KSCrash/KSCrash/KSCrashSentry_CPPExceptionDisabled.c
@@ -1,7 +1,5 @@
 //
-//  KSCrashSentry_Private.h
-//
-//  Created by Karl Stenerud on 2012-09-29.
+//  KSCrashSentry_CPPThrowHandler.c
 //
 //  Copyright (c) 2012 Karl Stenerud. All rights reserved.
 //
@@ -25,42 +23,19 @@
 //
 
 
-#ifndef HDR_KSCrashSentry_Private_h
-#define HDR_KSCrashSentry_Private_h
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-    
-#include "KSCrashSentry.h"
+#include "KSCrashSentry_CPPException.h"
 
 
-/** Suspend all non-reserved threads.
- *
- * Reserved threads include the current thread and all threads in
- "reservedThreads" in the context.
- */
-void kscrashsentry_suspendThreads(void);
+// ============================================================================
+#pragma mark - Public API -
+// ============================================================================
 
-/** Resume all non-reserved threads.
- *
- * Reserved threads include the current thread and all threads in
- * "reservedThreads" in the context.
- */
-void kscrashsentry_resumeThreads(void);
-
-/** Prepare the context for handling a new crash.
- */
-void kscrashsentry_beginHandlingCrash(KSCrash_SentryContext* context);
-
-/** Clear a crash sentry context.
- */
-void kscrashsentry_clearContext(KSCrash_SentryContext* context);
-
-    
-#ifdef __cplusplus
+__attribute((weak)) bool kscrashsentry_installCPPExceptionHandler(__unused KSCrash_SentryContext* context)
+{
+    return false;
 }
-#endif
 
-#endif // HDR_KSCrashSentry_Private_h
+__attribute((weak)) void kscrashsentry_uninstallCPPExceptionHandler(void)
+{
+    // Do nothing.
+}

--- a/KSCrash/KSCrash/KSCrashSentry_User.c
+++ b/KSCrash/KSCrash/KSCrashSentry_User.c
@@ -1,9 +1,25 @@
 //
 //  KSCrashSentry_User.c
-//  KSCrash
 //
-//  Created by Karl Stenerud on 6/4/13.
-//  Copyright (c) 2013 Karl Stenerud. All rights reserved.
+//  Copyright (c) 2012 Karl Stenerud. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 //
 
 #include "KSCrashSentry_User.h"

--- a/KSCrash/KSCrash/KSCrashSentry_User.h
+++ b/KSCrash/KSCrash/KSCrashSentry_User.h
@@ -1,9 +1,25 @@
 //
 //  KSCrashSentry_User.h
-//  KSCrash
 //
-//  Created by Karl Stenerud on 6/4/13.
-//  Copyright (c) 2013 Karl Stenerud. All rights reserved.
+//  Copyright (c) 2012 Karl Stenerud. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 //
 
 #ifndef HDR_KSCrashSentry_User_h

--- a/KSCrash/KSCrash/KSCrashState.c
+++ b/KSCrash/KSCrash/KSCrashState.c
@@ -426,3 +426,8 @@ void kscrashstate_notifyAppCrash(void)
     state->crashedThisLaunch = true;
     kscrashstate_i_saveState(state, stateFilePath);
 }
+
+const KSCrash_State* const kscrashstate_currentState(void)
+{
+    return g_state;
+}

--- a/KSCrash/KSCrash/KSCrashState.h
+++ b/KSCrash/KSCrash/KSCrashState.h
@@ -122,6 +122,10 @@ void kscrashstate_notifyAppTerminate(void);
  */
 void kscrashstate_notifyAppCrash(void);
 
+/** Read-only access into the current state.
+ */
+const KSCrash_State* const kscrashstate_currentState(void);
+
 
 #ifdef __cplusplus
 }

--- a/KSCrash/KSCrash/KSCrashType.c
+++ b/KSCrash/KSCrash/KSCrashType.c
@@ -1,0 +1,58 @@
+//
+//  KSCrashType.c
+//
+//  Copyright (c) 2012 Karl Stenerud. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+
+#include "KSCrashType.h"
+
+#include <stdlib.h>
+
+
+static const struct
+{
+    const KSCrashType type;
+    const char* const name;
+} g_crashTypes[] =
+{
+#define CRASHTYPE(NAME) {NAME, #NAME}
+    CRASHTYPE(KSCrashTypeMachException),
+    CRASHTYPE(KSCrashTypeSignal),
+    CRASHTYPE(KSCrashTypeCPPException),
+    CRASHTYPE(KSCrashTypeNSException),
+    CRASHTYPE(KSCrashTypeMainThreadDeadlock),
+    CRASHTYPE(KSCrashTypeUserReported),
+};
+static const int g_crashTypesCount = sizeof(g_crashTypes) / sizeof(*g_crashTypes);
+
+
+const char* kscrashtype_name(const KSCrashType crashType)
+{
+    for(int i = 0; i < g_crashTypesCount; i++)
+    {
+        if(g_crashTypes[i].type == crashType)
+        {
+            return g_crashTypes[i].name;
+        }
+    }
+    return NULL;
+}

--- a/KSCrash/KSCrash/KSCrashType.h
+++ b/KSCrash/KSCrash/KSCrashType.h
@@ -79,5 +79,6 @@ typedef enum
  */
 #define KSCrashTypeProductionSafe (KSCrashTypeAll & (~KSCrashTypeExperimental))
 
+const char* kscrashtype_name(KSCrashType crashType);
 
 #endif // HDR_KSCrashType_h

--- a/KSCrash/KSCrash/KSCrashType.h
+++ b/KSCrash/KSCrash/KSCrashType.h
@@ -1,0 +1,83 @@
+//
+//  KSCrashType.h
+//
+//  Copyright (c) 2012 Karl Stenerud. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+
+#ifndef HDR_KSCrashType_h
+#define HDR_KSCrashType_h
+
+
+/** Different ways an application can crash:
+ * - Mach kernel exception
+ * - Fatal signal
+ * - Uncaught C++ exception
+ * - Uncaught Objective-C NSException
+ * - Deadlock on the main thread
+ * - User reported custom exception
+ */
+typedef enum
+{
+    KSCrashTypeMachException      = 0x01,
+    KSCrashTypeSignal             = 0x02,
+    KSCrashTypeCPPException       = 0x04,
+    KSCrashTypeNSException        = 0x08,
+    KSCrashTypeMainThreadDeadlock = 0x10,
+    KSCrashTypeUserReported       = 0x20,
+} KSCrashType;
+
+#define KSCrashTypeAll              \
+(                                   \
+    KSCrashTypeMachException      | \
+    KSCrashTypeSignal             | \
+    KSCrashTypeCPPException       | \
+    KSCrashTypeNSException        | \
+    KSCrashTypeMainThreadDeadlock | \
+    KSCrashTypeUserReported         \
+)
+
+#define KSCrashTypeExperimental     \
+(                                   \
+    KSCrashTypeMainThreadDeadlock   \
+)
+
+#define KSCrashTypeDebuggerUnsafe   \
+(                                   \
+    KSCrashTypeMachException        \
+)
+
+#define KSCrashTypeAsyncSafe        \
+(                                   \
+    KSCrashTypeMachException      | \
+    KSCrashTypeSignal               \
+)
+
+/** Crash types that are safe to enable in a debugger. */
+#define KSCrashTypeDebuggerSafe (KSCrashTypeAll & (~KSCrashTypeDebuggerUnsafe))
+
+/** It is safe to catch these kinds of crashes in a production environment.
+ * All other crash types should be considered experimental.
+ */
+#define KSCrashTypeProductionSafe (KSCrashTypeAll & (~KSCrashTypeExperimental))
+
+
+#endif // HDR_KSCrashType_h

--- a/KSCrash/KSCrash/KSSysCtl.h
+++ b/KSCrash/KSCrash/KSSysCtl.h
@@ -177,6 +177,7 @@ struct timeval kssysctl_timevalForName(const char* name);
 bool kssysctl_getProcessInfo(int pid, struct kinfo_proc* procInfo);
 
 /** Get the MAC address of the specified interface.
+ * Note: As of iOS 7 this will always return a fixed value of 02:00:00:00:00:00.
  *
  * @param name Interface name (e.g. "en1").
  *

--- a/KSCrash/KSCrash/KSSystemInfo.m
+++ b/KSCrash/KSCrash/KSSystemInfo.m
@@ -304,7 +304,7 @@ const char* kssysteminfo_toJSON(void)
     return strdup([jsonData bytes]);
 }
 
-char* kssystemInfo_copyProcessName(void)
+char* kssysteminfo_copyProcessName(void)
 {
     return strdup([[NSProcessInfo processInfo].processName UTF8String]);
 }

--- a/KSCrash/KSCrash/KSSystemInfo.m
+++ b/KSCrash/KSCrash/KSSystemInfo.m
@@ -168,12 +168,17 @@
  */
 + (NSString*) deviceAndAppHash
 {
-    NSMutableData* data = [NSMutableData dataWithLength:6];
+    NSMutableData* data = nil;
 
-    // Get the MAC address.
-    if(!kssysctl_getMacAddress("en0", [data mutableBytes]))
+    if([[UIDevice currentDevice] respondsToSelector:@selector(identifierForVendor)])
     {
-        return nil;
+        data = [NSMutableData dataWithLength:16];
+        [[UIDevice currentDevice].identifierForVendor getUUIDBytes:data.mutableBytes];
+    }
+    else
+    {
+        data = [NSMutableData dataWithLength:6];
+        kssysctl_getMacAddress("en0", [data mutableBytes]);
     }
 
     // Append some device-specific data.

--- a/KSCrash/KSCrash/KSSystemInfoC.h
+++ b/KSCrash/KSCrash/KSSystemInfoC.h
@@ -47,7 +47,7 @@ const char* kssysteminfo_toJSON(void);
  *
  * @return The process name. Caller is responsible for calling free().
  */
-char* kssystemInfo_copyProcessName(void);
+char* kssysteminfo_copyProcessName(void);
 
 #ifdef __cplusplus
 }

--- a/KSCrash/KSCrash/KSZombie.m
+++ b/KSCrash/KSCrash/KSZombie.m
@@ -114,9 +114,12 @@ static inline void handleDealloc(id self)
     zombie->object = self;
     Class class = object_getClass(self);
     zombie->className = class_getName(class);
-    unlikely_if(class == g_lastDeallocedException.class)
+    for(; class != nil; class = class_getSuperclass(class))
     {
-        storeException(self);
+        unlikely_if(class == g_lastDeallocedException.class)
+        {
+            storeException(self);
+        }
     }
 }
 

--- a/KSCrash/KSCrashTests/KSCrashSentry_Tests.m
+++ b/KSCrash/KSCrashTests/KSCrashSentry_Tests.m
@@ -30,6 +30,10 @@
 #import "KSCrashSentry.h"
 #import "KSCrashSentry_Private.h"
 
+static void onCrash(void)
+{
+    // Do nothing
+}
 
 @interface KSCrashSentry_Tests : SenTestCase @end
 
@@ -39,7 +43,7 @@
 - (void) testInstallUninstall
 {
     KSCrash_SentryContext context;
-    kscrashsentry_installWithContext(&context, KSCrashTypeAll);
+    kscrashsentry_installWithContext(&context, KSCrashTypeAll, onCrash);
     kscrashsentry_uninstall(KSCrashTypeAll);
 }
 

--- a/KSCrash/KSCrashTests/KSSystemInfo_Tests.m
+++ b/KSCrash/KSCrashTests/KSSystemInfo_Tests.m
@@ -49,7 +49,7 @@
 
 - (void) testCopyProcessName
 {
-    char* processName = kssystemInfo_copyProcessName();
+    char* processName = kssysteminfo_copyProcessName();
     STAssertTrue(processName != NULL, @"");
     if(processName != NULL)
     {

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ of a lot more that they COULD do. Here are some key features of KSCrash:
   overflow.
 * Handles a crash in the crash handler itself (or in the user crash handler
   callback).
-* Detects deadlocks in the main loop.
 * Detects zombie (deallocated) object access attempts.
 * Recovers lost NSException messages in cases of zombies or memory corruption.
 * Introspects objects in registers and on the stack (C strings and Objective-C
@@ -32,6 +31,15 @@ of a lot more that they COULD do. Here are some key features of KSCrash:
   format.
 * Supports including extra data that the programmer supplies (before and during
   a crash).
+
+KSCrash handles the following kinds of crashes:
+
+* Mach kernel exceptions
+* Fatal signals
+* C++ exceptions
+* Objective-C exceptions
+* Main thread deadlock (experimental)
+* Custom crashes (e.g. from scripting languages)
 
 [Here are some examples of the reports it can generate.](https://github.com/kstenerud/KSCrash/tree/master/Example-Reports/_README.md)
 


### PR DESCRIPTION
https://mindsnacks.atlassian.net/browse/CHIM-153

Yes, we now support C++ exceptions!
If an exception is thrown, KSCrash will record what kind of exception it was, and for exceptions that subclass std::exception, it will record the result of exception->what(). For all primitive types (int, float, char*) it will record the raw values (or strings).

With the following code:

```
class MyException: public std::exception
{
public:
    virtual const char* what() const noexcept;
};

const char* MyException::what() const noexcept
{
    return "Something bad happened...";
}

- (void) throwUncaughtCPPException
{
    throw MyException();
}
```

An unhandled C++ exception crash will look like this:

```
Exception Type:  EXC_CRASH (SIGABRT)
Exception Codes: 0x00000000 at 0x00000000
Crashed Thread:  0

Application Specific Information:
*** Terminating app due to uncaught exception 'MyException', reason: 'Something bad happened...'

Thread 0 name:  Dispatch queue: com.apple.main-thread
Thread 0 Crashed:
0   Crash-Tester                    0x0008e32b 0x85000 + 37675 (-[Crasher throwUncaughtCPPException] + 87)
1   Crash-Tester                    0x0008c10b 0x85000 + 28939 (__32-[AppDelegate(UI) crashCommands]_block_invoke343 + 75)
2   Crash-Tester                    0x0008ccfb 0x85000 + 31995 (-[CommandEntry executeWithViewController:] + 59)
3   Crash-Tester                    0x0008d3a9 0x85000 + 33705 (-[CommandTVC tableView:didSelectRowAtIndexPath:] + 193)
4   UIKit                           0x38ee626d 0x38e21000 + 807533 (<redacted> + 877)
...
```

Review:
- [x] @JaviSoto 
- [x] @tedw4rd 
