### PR TITLE
Exposed statistical information about app launches and crashes via KSCrashAdvanced.

### DIFF
--- a/KSCrash/KSCrash/KSCrash.m
+++ b/KSCrash/KSCrash/KSCrash.m
@@ -363,6 +363,21 @@ failed:
 #pragma mark - Advanced API -
 // ============================================================================
 
+#define SYNTHESIZE_CRASH_STATE_PROPERTY(TYPE, NAME) \
+- (TYPE) NAME \
+{ \
+    return kscrashstate_currentState()->NAME; \
+}
+
+SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, activeDurationSinceLastCrash)
+SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, backgroundDurationSinceLastCrash)
+SYNTHESIZE_CRASH_STATE_PROPERTY(int, launchesSinceLastCrash)
+SYNTHESIZE_CRASH_STATE_PROPERTY(int, sessionsSinceLastCrash)
+SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, activeDurationSinceLaunch)
+SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, backgroundDurationSinceLaunch)
+SYNTHESIZE_CRASH_STATE_PROPERTY(int, sessionsSinceLaunch)
+SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
+
 - (NSUInteger) reportCount
 {
     return [self.crashReportStore reportCount];

--- a/KSCrash/KSCrash/KSCrashAdvanced.h
+++ b/KSCrash/KSCrash/KSCrashAdvanced.h
@@ -34,6 +34,43 @@
  */
 @interface KSCrash (Advanced)
 
+#pragma mark - Information -
+
+/** Total active time elapsed since the last crash. */
+@property(nonatomic,readonly,assign) NSTimeInterval activeDurationSinceLastCrash;
+
+/** Total time backgrounded elapsed since the last crash. */
+@property(nonatomic,readonly,assign) NSTimeInterval backgroundDurationSinceLastCrash;
+
+/** Number of app launches since the last crash. */
+@property(nonatomic,readonly,assign) int launchesSinceLastCrash;
+
+/** Number of sessions (launch, resume from suspend) since last crash. */
+@property(nonatomic,readonly,assign) int sessionsSinceLastCrash;
+
+/** Total active time elapsed since launch. */
+@property(nonatomic,readonly,assign) NSTimeInterval activeDurationSinceLaunch;
+
+/** Total time backgrounded elapsed since launch. */
+@property(nonatomic,readonly,assign) NSTimeInterval backgroundDurationSinceLaunch;
+
+/** Number of sessions (launch, resume from suspend) since app launch. */
+@property(nonatomic,readonly,assign) int sessionsSinceLaunch;
+
+/** If true, the application crashed on the previous launch. */
+@property(nonatomic,readonly,assign) BOOL crashedLastLaunch;
+
+/** The total number of unsent reports. Note: This is an expensive operation.
+ */
+- (NSUInteger) reportCount;
+
+/** Get all reports, with data types corrected, as dictionaries.
+ */
+- (NSArray*) allReports;
+
+
+#pragma mark - Configuration -
+
 /** Store containing all crash reports. */
 @property(nonatomic, readwrite, retain) KSCrashReportStore* crashReportStore;
 
@@ -46,21 +83,6 @@
  * Default: nil
  */
 @property(nonatomic, readonly, retain) NSString* logFilePath;
-
-/** Send the specified reports to the current sink.
- *
- * @param reports The reports to send.
- * @param onCompletion Called when sending is complete (nil = ignore).
- */
-- (void) sendReports:(NSArray*) reports onCompletion:(KSCrashReportFilterCompletion) onCompletion;
-
-/** The total number of unsent reports. Note: This is an expensive operation.
- */
-- (NSUInteger) reportCount;
-
-/** Get all reports, with data types corrected, as dictionaries.
- */
-- (NSArray*) allReports;
 
 /** Sets logFilePath to the default log file location
  * (Library/Caches/KSCrashReports/<bundle name>-CrashLog.txt).
@@ -79,5 +101,14 @@
  */
 - (BOOL) redirectConsoleLogsToFile:(NSString*) fullPath overwrite:(BOOL) overwrite;
 
-@end
 
+#pragma mark - Operations -
+
+/** Send the specified reports to the current sink.
+ *
+ * @param reports The reports to send.
+ * @param onCompletion Called when sending is complete (nil = ignore).
+ */
+- (void) sendReports:(NSArray*) reports onCompletion:(KSCrashReportFilterCompletion) onCompletion;
+
+@end

--- a/KSCrash/KSCrash/KSCrashReport.c
+++ b/KSCrash/KSCrash/KSCrashReport.c
@@ -1029,7 +1029,7 @@ void kscrw_i_writeAddressReferencedByString(const KSCrashReportWriter* const wri
                                             const char* string)
 {
     uint64_t address = 0;
-    if(!ksstring_extractHexValue(string, strlen(string), &address))
+    if(string == NULL || !ksstring_extractHexValue(string, strlen(string), &address))
     {
         return;
     }

--- a/KSCrash/KSCrash/KSCrashReportFilterAppleFmt.m
+++ b/KSCrash/KSCrash/KSCrashReportFilterAppleFmt.m
@@ -511,6 +511,7 @@ NSDictionary* g_registerOrders;
 
     [str appendString:@"\nExtra Information:\n"];
 
+    NSDictionary* system = [self systemReport:report];
     NSDictionary* crash = [self crashReport:report];
     NSDictionary* error = [crash objectForKey:@KSCrashField_Error];
     NSDictionary* nsexception = [error objectForKey:@KSCrashField_NSException];
@@ -556,6 +557,12 @@ NSDictionary* g_registerOrders;
          [self backtraceString:[lastException objectForKey:@KSCrashField_Backtrace]
                    reportStyle:self.reportStyle
             mainExecutableName:mainExecutableName]];
+    }
+
+    NSDictionary* appStats = [system objectForKey:@KSCrashField_AppStats];
+    if(appStats != nil)
+    {
+        [str appendFormat:@"\nApplication Stats:\n%@\n", [self JSONForObject:appStats]];
     }
 
     NSDictionary* crashReport = [report objectForKey:@KSCrashField_Crash];

--- a/KSCrash/KSCrash/KSCrashState.c
+++ b/KSCrash/KSCrash/KSCrashState.c
@@ -426,3 +426,8 @@ void kscrashstate_notifyAppCrash(void)
     state->crashedThisLaunch = true;
     kscrashstate_i_saveState(state, stateFilePath);
 }
+
+const KSCrash_State* const kscrashstate_currentState(void)
+{
+    return g_state;
+}

--- a/KSCrash/KSCrash/KSCrashState.h
+++ b/KSCrash/KSCrash/KSCrashState.h
@@ -122,6 +122,10 @@ void kscrashstate_notifyAppTerminate(void);
  */
 void kscrashstate_notifyAppCrash(void);
 
+/** Read-only access into the current state.
+ */
+const KSCrash_State* const kscrashstate_currentState(void);
+
 
 #ifdef __cplusplus
 }

--- a/KSCrash/KSCrash/KSZombie.m
+++ b/KSCrash/KSCrash/KSZombie.m
@@ -114,9 +114,12 @@ static inline void handleDealloc(id self)
     zombie->object = self;
     Class class = object_getClass(self);
     zombie->className = class_getName(class);
-    unlikely_if(class == g_lastDeallocedException.class)
+    for(; class != nil; class = class_getSuperclass(class))
     {
-        storeException(self);
+        unlikely_if(class == g_lastDeallocedException.class)
+        {
+            storeException(self);
+        }
     }
 }
 


### PR DESCRIPTION
Also added application stats to the Apple crash reports, which look something like this:

```
Application Stats:
{
    "active_time_since_last_crash": 7.66881,
    "active_time_since_launch": 7.66881,
    "application_active": true,
    "application_in_foreground": true,
    "background_time_since_last_crash": 4.17254,
    "background_time_since_launch": 4.17254,
    "launches_since_last_crash": 3,
    "sessions_since_last_crash": 5,
    "sessions_since_launch": 3
}
```

Where:
- Session means a transition to foreground state.
- Time is measured in seconds.

Review:
- [x] @JaviSoto 
